### PR TITLE
[B‑2] Define Tile model (color & kind enums)

### DIFF
--- a/assets/scripts/core/board/Tile.ts
+++ b/assets/scripts/core/board/Tile.ts
@@ -1,0 +1,57 @@
+/**
+ * Определения модели игрового тайла.
+ */
+
+/**
+ * Допустимые цвета тайлов на поле.
+ */
+export type TileColor = "red" | "blue" | "green" | "yellow" | "purple";
+
+/**
+ * Перечисление видов тайлов.
+ */
+export enum TileKind {
+  /** обычный тайл */
+  Normal,
+  /** супер‑тайл: сжигает строку */
+  SuperRow,
+  /** супер‑тайл: сжигает столбец */
+  SuperCol,
+  /** радиус R */
+  SuperBomb,
+  /** очищает всё поле */
+  SuperClear,
+}
+
+/**
+ * Интерфейс игрового тайла.
+ */
+export interface Tile {
+  /** уникальный идентификатор */
+  id: number;
+  /** цвет тайла */
+  color: TileColor;
+  /** тип тайла */
+  kind: TileKind;
+}
+
+/**
+ * Фабрика для создания тайлов.
+ */
+export class TileFactory {
+  /** счётчик идентификаторов */
+  private static nextId = 0;
+
+  /**
+   * Создаёт обычный тайл заданного цвета.
+   * @param color Цвет тайла
+   * @returns Новый тайл с типом {@link TileKind.Normal}
+   */
+  public static createNormal(color: TileColor): Tile {
+    return {
+      id: ++this.nextId,
+      color,
+      kind: TileKind.Normal,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- define `TileColor`, `TileKind`, and `Tile` in `Tile.ts`
- add `TileFactory` to create normal tiles

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688927c6871c8320bcec530a45e8e3a0