### PR TITLE
[C‑2] Implement MoveExecutor & Commands

### DIFF
--- a/assets/scripts/core/board/MoveExecutor.ts
+++ b/assets/scripts/core/board/MoveExecutor.ts
@@ -1,0 +1,51 @@
+import { Vec2 } from "cc";
+import { Board } from "./Board";
+import { EventEmitter2 } from "eventemitter2";
+import { RemoveCommand } from "./commands/RemoveCommand";
+import { FallCommand } from "./commands/FallCommand";
+import { FillCommand } from "./commands/FillCommand";
+
+/**
+ * Executes a full player move by removing a group, letting tiles fall
+ * and filling empty spaces. Commands are executed sequentially and the
+ * method resolves once all operations are complete.
+ */
+export class MoveExecutor {
+  constructor(
+    private board: Board,
+    private bus: EventEmitter2,
+  ) {}
+
+  async execute(group: Vec2[]): Promise<void> {
+    if (group.length === 0) {
+      throw new Error("MoveExecutor: group is empty");
+    }
+
+    // 1. Remove tiles and wait for completion
+    const removeDone = this.wait("removeDone");
+    new RemoveCommand(this.board, this.bus, group).execute();
+    const [dirtyCols] = (await removeDone) as [number[]];
+
+    // 2. Let tiles fall in affected columns
+    const fallDone = this.wait("fallDone");
+    new FallCommand(this.board, this.bus, dirtyCols).execute();
+    const [emptySlots] = (await fallDone) as [Vec2[]];
+
+    // 3. Fill empty spaces with new tiles
+    const fillDone = this.wait("fillDone");
+    new FillCommand(this.board, this.bus, emptySlots).execute();
+    await fillDone;
+
+    // Signal completion of the whole move
+    this.bus.emit("MoveCompleted");
+  }
+
+  /**
+   * Helper that returns a promise resolved when the given event fires.
+   */
+  private wait(event: string): Promise<unknown[]> {
+    return new Promise((resolve) => {
+      this.bus.once(event, (...args: unknown[]) => resolve(args));
+    });
+  }
+}

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -1,0 +1,61 @@
+import { Vec2 } from "cc";
+import { Board } from "../Board";
+import { EventEmitter2 } from "eventemitter2";
+import { ICommand } from "./ICommand";
+import { Tile } from "../Tile";
+import { BoardConfig } from "../../../config/BoardConfig";
+
+/**
+ * Shifts tiles down in specified columns to remove gaps.
+ * Emits 'fallStart' and 'fallDone'. The 'fallDone' event carries
+ * the list of coordinates that became empty at the top of columns
+ * after falling which should be filled by the next command.
+ */
+export class FallCommand implements ICommand {
+  constructor(
+    private board: Board,
+    private bus: EventEmitter2,
+    private columns: number[],
+  ) {}
+
+  private get cfg(): BoardConfig {
+    // Access board configuration for dimensions without exposing private field
+    return (this.board as unknown as { cfg: BoardConfig }).cfg;
+  }
+
+  async execute(): Promise<void> {
+    if (this.columns.length === 0) {
+      throw new Error("FallCommand: no columns specified");
+    }
+
+    this.bus.emit("fallStart", this.columns);
+
+    const emptySlots: Vec2[] = [];
+    const rows = this.cfg.rows;
+
+    for (const x of this.columns) {
+      const kept: Tile[] = [];
+      // Collect existing tiles from bottom to top
+      for (let y = rows - 1; y >= 0; y--) {
+        const t = this.board.tileAt(new Vec2(x, y));
+        if (t) {
+          kept.push(t);
+        }
+      }
+      // Place tiles starting from bottom
+      let y = rows - 1;
+      for (const t of kept) {
+        this.board.setTile(new Vec2(x, y), t);
+        y--;
+      }
+      // Clear remaining cells and record them as empty
+      for (; y >= 0; y--) {
+        const p = new Vec2(x, y);
+        this.board.setTile(p, null);
+        emptySlots.push(p);
+      }
+    }
+
+    this.bus.emit("fallDone", emptySlots);
+  }
+}

--- a/assets/scripts/core/board/commands/FillCommand.ts
+++ b/assets/scripts/core/board/commands/FillCommand.ts
@@ -1,0 +1,45 @@
+import { Vec2 } from "cc";
+import { Board } from "../Board";
+import { EventEmitter2 } from "eventemitter2";
+import { ICommand } from "./ICommand";
+import { TileFactory, TileColor } from "../Tile";
+import { BoardConfig } from "../../../config/BoardConfig";
+
+/**
+ * Generates new tiles in provided empty slots.
+ * Emits 'fillStart' and 'fillDone'. No payload is passed with 'fillDone'.
+ */
+export class FillCommand implements ICommand {
+  constructor(
+    private board: Board,
+    private bus: EventEmitter2,
+    private slots: Vec2[],
+  ) {}
+
+  private get cfg(): BoardConfig {
+    // Retrieve board configuration through type casting to avoid exposing field
+    return (this.board as unknown as { cfg: BoardConfig }).cfg;
+  }
+
+  async execute(): Promise<void> {
+    if (this.slots.length === 0) {
+      throw new Error("FillCommand: no slots provided");
+    }
+
+    this.bus.emit("fillStart", this.slots);
+
+    for (const p of this.slots) {
+      if (!this.board.inBounds(p)) continue;
+      const color = this.randomColor();
+      this.board.setTile(p, TileFactory.createNormal(color));
+    }
+
+    this.bus.emit("fillDone");
+  }
+
+  private randomColor(): TileColor {
+    const colors = this.cfg.colors;
+    const idx = Math.floor(Math.random() * colors.length);
+    return colors[idx] as TileColor;
+  }
+}

--- a/assets/scripts/core/board/commands/ICommand.ts
+++ b/assets/scripts/core/board/commands/ICommand.ts
@@ -1,0 +1,3 @@
+export interface ICommand {
+  execute(): Promise<void>;
+}

--- a/assets/scripts/core/board/commands/RemoveCommand.ts
+++ b/assets/scripts/core/board/commands/RemoveCommand.ts
@@ -1,0 +1,39 @@
+import { Vec2 } from "cc";
+import { Board } from "../Board";
+import { EventEmitter2 } from "eventemitter2";
+import { ICommand } from "./ICommand";
+
+/**
+ * Removes tiles belonging to the provided group from the board.
+ * Emits 'removeStart' at the beginning and 'removeDone' with affected
+ * column indices when finished.
+ */
+export class RemoveCommand implements ICommand {
+  constructor(
+    private board: Board,
+    private bus: EventEmitter2,
+    private group: Vec2[],
+  ) {}
+
+  async execute(): Promise<void> {
+    if (this.group.length === 0) {
+      throw new Error("RemoveCommand: group is empty");
+    }
+
+    // Notify listeners that removal has started
+    this.bus.emit("removeStart", this.group);
+
+    const cols = new Set<number>();
+    for (const p of this.group) {
+      // Ignore coordinates outside the board
+      if (!this.board.inBounds(p)) continue;
+      if (this.board.tileAt(p)) {
+        this.board.setTile(p, null);
+        cols.add(p.x);
+      }
+    }
+
+    // Emit completion event with affected column numbers
+    this.bus.emit("removeDone", Array.from(cols));
+  }
+}

--- a/tests/MoveExecutor.spec.ts
+++ b/tests/MoveExecutor.spec.ts
@@ -1,0 +1,50 @@
+import { Vec2 } from "cc";
+import { Board } from "../assets/scripts/core/board/Board";
+import { BoardConfig } from "../assets/scripts/config/BoardConfig";
+import { TileFactory } from "../assets/scripts/core/board/Tile";
+import { EventBus } from "../assets/scripts/core/EventBus";
+import { MoveExecutor } from "../assets/scripts/core/board/MoveExecutor";
+
+describe("MoveExecutor", () => {
+  const cfg: BoardConfig = {
+    cols: 2,
+    rows: 2,
+    tileSize: 1,
+    colors: ["red"],
+    superThreshold: 3,
+  };
+
+  beforeEach(() => {
+    EventBus.removeAllListeners();
+  });
+
+  test("executes commands in sequence and emits events", async () => {
+    const tiles = [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+      [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+    ];
+    const board = new Board(cfg, tiles);
+    const executor = new MoveExecutor(board, EventBus);
+
+    const events: string[] = [];
+    EventBus.on("removeDone", () => events.push("removeDone"));
+    EventBus.on("fallDone", () => events.push("fallDone"));
+    EventBus.on("fillDone", () => events.push("fillDone"));
+    EventBus.on("MoveCompleted", () => events.push("MoveCompleted"));
+
+    await executor.execute([new Vec2(0, 1), new Vec2(1, 1)]);
+
+    expect(events).toEqual([
+      "removeDone",
+      "fallDone",
+      "fillDone",
+      "MoveCompleted",
+    ]);
+  });
+
+  test("throws when group is empty", async () => {
+    const board = new Board(cfg);
+    const executor = new MoveExecutor(board, EventBus);
+    await expect(executor.execute([])).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add command pattern classes RemoveCommand/FallCommand/FillCommand
- orchestrate them with MoveExecutor
- test that MoveExecutor emits events in order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894132e91c8320997b059680d74613