### PR TITLE
Implement scoring strategy with quadratic formula

### DIFF
--- a/assets/scripts/core/rules/ScoreStrategy.ts
+++ b/assets/scripts/core/rules/ScoreStrategy.ts
@@ -1,0 +1,6 @@
+export interface ScoreStrategy {
+  /**
+   * Returns score for a group of size n.
+   */
+  calculate(groupSize: number): number;
+}

--- a/assets/scripts/core/rules/ScoreStrategyQuadratic.ts
+++ b/assets/scripts/core/rules/ScoreStrategyQuadratic.ts
@@ -1,0 +1,26 @@
+import { ScoreStrategy } from "./ScoreStrategy";
+
+/**
+ * Quadratic scoring strategy rewarding large groups.
+ *
+ * Points are calculated as `(size - 1)^2 * multiplier`. Subtracting one
+ * makes single-tile groups worth zero points, encouraging players to clear
+ * at least two tiles. Squaring the size rapidly increases reward for large
+ * groups so players aim for big combos. The multiplier adjusts overall pace
+ * of scoring.
+ */
+export class ScoreStrategyQuadratic implements ScoreStrategy {
+  /**
+   * @param multiplier Coefficient applied to the quadratic result. Defaults to 10.
+   */
+  constructor(private multiplier = 10) {}
+
+  /**
+   * Calculates score for the given group size.
+   * @param size Number of tiles in the removed group
+   * @returns Amount of points awarded
+   */
+  calculate(size: number): number {
+    return Math.pow(size - 1, 2) * this.multiplier;
+  }
+}

--- a/tests/ScoreStrategyQuadratic.spec.ts
+++ b/tests/ScoreStrategyQuadratic.spec.ts
@@ -1,0 +1,8 @@
+import { ScoreStrategyQuadratic } from "../assets/scripts/core/rules/ScoreStrategyQuadratic";
+
+describe("ScoreStrategyQuadratic", () => {
+  test("calculates score with multiplier", () => {
+    const strategy = new ScoreStrategyQuadratic(5);
+    expect(strategy.calculate(4)).toBe(45);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ScoreStrategy` interface
- implement `ScoreStrategyQuadratic` with configurable multiplier
- test scoring formula

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889445c85dc832099c0b44bddbe1836