### PR TITLE
Implement TurnManager

### DIFF
--- a/assets/scripts/core/rules/TurnManager.ts
+++ b/assets/scripts/core/rules/TurnManager.ts
@@ -1,0 +1,38 @@
+import { EventEmitter2 } from "eventemitter2";
+export class TurnManager {
+  /** Remaining turns in the current session. */
+  private turnsLeft: number;
+
+  /**
+   * Creates a turn manager with the given initial amount of turns.
+   * @param initialTurns Starting number of turns
+   * @param bus Event bus used to emit turn related events
+   */
+  constructor(
+    initialTurns: number,
+    private bus: EventEmitter2,
+  ) {
+    this.turnsLeft = initialTurns;
+  }
+
+  /**
+   * Consumes one turn and notifies listeners.
+   *
+   * Emits `TurnUsed` with remaining turns after decrement. When no turns
+   * remain the `OutOfTurns` event is emitted once the count reaches zero.
+   */
+  useTurn(): void {
+    this.turnsLeft--;
+    this.bus.emit("TurnUsed", this.turnsLeft);
+    if (this.turnsLeft === 0) {
+      this.bus.emit("OutOfTurns");
+    }
+  }
+
+  /**
+   * Returns the number of turns still available.
+   */
+  getRemaining(): number {
+    return this.turnsLeft;
+  }
+}

--- a/tests/TurnManager.spec.ts
+++ b/tests/TurnManager.spec.ts
@@ -1,0 +1,27 @@
+import { EventEmitter2 } from "eventemitter2";
+import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
+
+describe("TurnManager", () => {
+  test("counts down turns and emits TurnUsed", () => {
+    const bus = new EventEmitter2();
+    const tm = new TurnManager(5, bus);
+    const used: number[] = [];
+    bus.on("TurnUsed", (left: number) => used.push(left));
+    tm.useTurn();
+    tm.useTurn();
+    tm.useTurn();
+    expect(tm.getRemaining()).toBe(2);
+    expect(used).toEqual([4, 3, 2]);
+  });
+
+  test("OutOfTurns emitted when reaching zero", () => {
+    const bus = new EventEmitter2();
+    const tm = new TurnManager(2, bus);
+    let count = 0;
+    bus.on("OutOfTurns", () => count++);
+    tm.useTurn();
+    expect(count).toBe(0);
+    tm.useTurn();
+    expect(count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a TurnManager class for tracking player turns
- tests for TurnManager logic

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688947d67eb483208a4315f9511254ba