### PR TITLE
Implement GameStateMachine (state transitions)

### DIFF
--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -1,0 +1,188 @@
+export type GameState =
+  | "WaitingInput"
+  | "ExecutingMove"
+  | "TilesFalling"
+  | "Filling"
+  | "CheckEnd"
+  | "Shuffle"
+  | "BoosterInput"
+  | "Win"
+  | "Lose";
+
+import { Vec2 } from "cc";
+import { EventEmitter2 } from "eventemitter2";
+import { Board } from "../board/Board";
+import { BoardSolver } from "../board/BoardSolver";
+import { MoveExecutor } from "../board/MoveExecutor";
+import { ScoreStrategy } from "../rules/ScoreStrategy";
+import { TurnManager } from "../rules/TurnManager";
+import { BoardConfig } from "../../config/BoardConfig";
+
+/**
+ * Finite state machine orchestrating a single game session.
+ * All state changes are propagated through the provided event bus.
+ */
+export class GameStateMachine {
+  /** Current FSM state. */
+  private state: GameState = "WaitingInput";
+  /** Accumulated player score. */
+  private score = 0;
+  /** How many times the board was shuffled. */
+  private shuffles = 0;
+
+  constructor(
+    private bus: EventEmitter2,
+    private board: Board,
+    private solver: BoardSolver,
+    private executor: MoveExecutor,
+    private scoreStrategy: ScoreStrategy,
+    private turnManager: TurnManager,
+    private targetScore: number,
+    private maxShuffles: number = 3,
+  ) {}
+
+  /**
+   * Subscribe to relevant events and enter the initial WaitingInput state.
+   */
+  start(): void {
+    this.bus.on("GroupSelected", (p: Vec2) => this.onGroupSelected(p));
+    this.bus.on("BoosterActivated", () => this.onBoosterActivated());
+    this.bus.on("BoosterConsumed", () => this.onBoosterConsumed());
+    this.bus.on("BoosterCancelled", () => this.onBoosterCancelled());
+    this.bus.on("MoveCompleted", () => this.onMoveCompleted());
+    this.changeState("WaitingInput");
+  }
+
+  /**
+   * Handles selection of a group by the player.
+   * Ignored unless the machine awaits input.
+   */
+  private onGroupSelected(start: Vec2): void {
+    if (this.state !== "WaitingInput") {
+      // Ignore input while another action is executing
+      return;
+    }
+
+    // Determine group of connected tiles and calculate score
+    const group = this.solver.findGroup(start);
+    if (group.length === 0) return;
+
+    this.turnManager.useTurn();
+    this.score += this.scoreStrategy.calculate(group.length);
+    this.changeState("ExecutingMove");
+
+    // Execute the move asynchronously; further states advance on MoveCompleted
+    void this.executor.execute(group);
+  }
+
+  /** Enters booster targeting mode when allowed. */
+  private onBoosterActivated(): void {
+    if (this.state === "WaitingInput") {
+      this.changeState("BoosterInput");
+    }
+  }
+
+  /** Consumes a booster and proceeds to executing it. */
+  private onBoosterConsumed(): void {
+    if (this.state === "BoosterInput") {
+      this.changeState("ExecutingMove");
+    }
+  }
+
+  /** Cancels booster usage returning to normal input. */
+  private onBoosterCancelled(): void {
+    if (this.state === "BoosterInput") {
+      this.changeState("WaitingInput");
+    }
+  }
+
+  /**
+   * Triggered when MoveExecutor signals completion of tile removal/fall/fill.
+   * Advances through remaining states and evaluates win/lose conditions.
+   */
+  private onMoveCompleted(): void {
+    if (this.state !== "ExecutingMove") return;
+    // Transition through remaining post-move phases
+    this.changeState("TilesFalling");
+    this.changeState("Filling");
+    this.changeState("CheckEnd");
+    this.evaluateEnd();
+  }
+
+  /**
+   * Checks end conditions and moves to the next appropriate state.
+   */
+  private evaluateEnd(): void {
+    const hasMoves = this.hasAvailableMoves();
+    const turns = this.turnManager.getRemaining();
+
+    if (this.score >= this.targetScore) {
+      this.changeState("Win");
+      return;
+    }
+
+    if (!hasMoves && this.shuffles < this.maxShuffles) {
+      this.changeState("Shuffle");
+      this.shuffleBoard();
+      this.shuffles++;
+      this.changeState("WaitingInput");
+      return;
+    }
+
+    if (turns === 0 || (!hasMoves && this.shuffles >= this.maxShuffles)) {
+      this.changeState("Lose");
+      return;
+    }
+
+    this.changeState("WaitingInput");
+  }
+
+  /**
+   * Emits a new state via the event bus and stores it internally.
+   */
+  private changeState(newState: GameState): void {
+    this.state = newState;
+    this.bus.emit("StateChanged", newState);
+  }
+
+  /**
+   * Determines whether any moves remain on the board by searching for
+   * adjacent tiles sharing the same color.
+   */
+  private hasAvailableMoves(): boolean {
+    let found = false;
+    this.board.forEach((p, tile) => {
+      if (found) return;
+      for (const n of this.board.neighbors4(p)) {
+        const other = this.board.tileAt(n);
+        if (other && other.color === tile.color) {
+          found = true;
+          break;
+        }
+      }
+    });
+    return found;
+  }
+
+  /** Randomly shuffles all tiles on the board in place. */
+  private shuffleBoard(): void {
+    const cfg = (this.board as unknown as { cfg: BoardConfig }).cfg;
+    const tiles: ReturnType<typeof this.board.tileAt>[] = [];
+    for (let y = 0; y < cfg.rows; y++) {
+      for (let x = 0; x < cfg.cols; x++) {
+        tiles.push(this.board.tileAt(new Vec2(x, y)));
+      }
+    }
+    // Fisher–Yates shuffle
+    for (let i = tiles.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [tiles[i], tiles[j]] = [tiles[j], tiles[i]];
+    }
+    let idx = 0;
+    for (let y = 0; y < cfg.rows; y++) {
+      for (let x = 0; x < cfg.cols; x++) {
+        this.board.setTile(new Vec2(x, y), tiles[idx++] ?? null);
+      }
+    }
+  }
+}

--- a/tests/GameStateMachine.spec.ts
+++ b/tests/GameStateMachine.spec.ts
@@ -1,0 +1,113 @@
+import { Vec2 } from "cc";
+import { EventBus } from "../assets/scripts/core/EventBus";
+import {
+  GameStateMachine,
+  GameState,
+} from "../assets/scripts/core/game/GameStateMachine";
+import { Board } from "../assets/scripts/core/board/Board";
+import { BoardSolver } from "../assets/scripts/core/board/BoardSolver";
+import { MoveExecutor } from "../assets/scripts/core/board/MoveExecutor";
+import { TileFactory } from "../assets/scripts/core/board/Tile";
+import { BoardConfig } from "../assets/scripts/config/BoardConfig";
+import { ScoreStrategyQuadratic } from "../assets/scripts/core/rules/ScoreStrategyQuadratic";
+import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
+
+describe("GameStateMachine", () => {
+  const cfg: BoardConfig = {
+    cols: 2,
+    rows: 2,
+    tileSize: 1,
+    colors: ["red"],
+    superThreshold: 3,
+  };
+
+  beforeEach(() => {
+    EventBus.removeAllListeners();
+  });
+
+  function createFSM(target = 10, board?: Board): GameStateMachine {
+    const b =
+      board ??
+      new Board(cfg, [
+        [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+        [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+      ]);
+    const solver = new BoardSolver(b);
+    const exec = new MoveExecutor(b, EventBus);
+    const strategy = new ScoreStrategyQuadratic(1);
+    const tm = new TurnManager(5, EventBus);
+    return new GameStateMachine(
+      EventBus,
+      b,
+      solver,
+      exec,
+      strategy,
+      tm,
+      target,
+      3,
+    );
+  }
+
+  test("start emits WaitingInput", () => {
+    const fsm = createFSM();
+    const states: GameState[] = [];
+    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    fsm.start();
+    expect(states).toEqual(["WaitingInput"]);
+  });
+
+  test("group selection performs full move sequence", async () => {
+    const fsm = createFSM();
+    const states: GameState[] = [];
+    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    fsm.start();
+    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    await new Promise((r) => setImmediate(r));
+    expect(states.slice(0, 5)).toEqual([
+      "WaitingInput",
+      "ExecutingMove",
+      "TilesFalling",
+      "Filling",
+      "CheckEnd",
+    ]);
+  });
+
+  test("win when reaching target score", async () => {
+    const fsm = createFSM(5); // easy target
+    const states: GameState[] = [];
+    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    fsm.start();
+    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    await new Promise((r) => setImmediate(r));
+    expect(states).toContain("Win");
+  });
+
+  test("deadlock triggers shuffle", async () => {
+    const singleCfg: BoardConfig = {
+      cols: 1,
+      rows: 1,
+      tileSize: 1,
+      colors: ["red"],
+      superThreshold: 3,
+    };
+    const board = new Board(singleCfg, [[TileFactory.createNormal("red")]]);
+    const fsm = createFSM(20, board);
+    const states: GameState[] = [];
+    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    fsm.start();
+    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    await new Promise((r) => setImmediate(r));
+    const lastTwo = states.slice(-2);
+    expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);
+  });
+
+  test("input ignored during execution", () => {
+    const fsm = createFSM();
+    const states: GameState[] = [];
+    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    fsm.start();
+    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    EventBus.emit("GroupSelected", new Vec2(0, 1));
+    expect(states.filter((s) => s === "ExecutingMove")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement game state machine coordinating turn flow
- add comprehensive tests for the new FSM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894be9b1448320bcdf2a8ba24141ef