### PR TITLE
Implement ShuffleService

### DIFF
--- a/assets/scripts/core/board/BoardSolver.ts
+++ b/assets/scripts/core/board/BoardSolver.ts
@@ -56,4 +56,26 @@ export class BoardSolver {
     EventBus.emit("GroupFound", result);
     return result;
   }
+
+  /**
+   * Determines whether any valid moves exist on the board.
+   * A move is considered available when two orthogonally
+   * adjacent tiles share the same color.
+   */
+  hasMoves(): boolean {
+    let found = false;
+    // Iterate over all tiles on the board
+    this.board.forEach((p, tile) => {
+      if (found) return; // early exit when at least one move is found
+      // Check 4-directional neighbours for a tile of the same color
+      for (const n of this.board.neighbors4(p)) {
+        const other = this.board.tileAt(n);
+        if (other && other.color === tile.color) {
+          found = true;
+          break;
+        }
+      }
+    });
+    return found;
+  }
 }

--- a/assets/scripts/core/board/ShuffleService.ts
+++ b/assets/scripts/core/board/ShuffleService.ts
@@ -1,0 +1,81 @@
+import { Vec2 } from "cc";
+import { EventEmitter2 } from "eventemitter2";
+import { Board } from "./Board";
+import { BoardSolver } from "./BoardSolver";
+import { Tile } from "./Tile";
+import { BoardConfig } from "../../config/BoardConfig";
+
+export class ShuffleService {
+  private shuffleCount = 0;
+  constructor(
+    private board: Board,
+    private solver: BoardSolver,
+    private bus: EventEmitter2,
+    private maxShuffles: number = 3,
+  ) {}
+
+  /**
+   * Проверяет наличие ходов и при их отсутствии:
+   * - если shuffleCount < maxShuffles:
+   *     эмит 'AutoShuffle', вызывает shuffle() и инкрементирует счётчик;
+   * - иначе эмит 'ShuffleLimitExceeded'.
+   */
+  ensureMoves(): void {
+    if (this.solver.hasMoves()) {
+      // Если ход есть, ничего не делаем.
+      return;
+    }
+
+    if (this.shuffleCount < this.maxShuffles) {
+      // Сообщаем, что будет автоматическая перетасовка.
+      this.bus.emit("AutoShuffle");
+      // Увеличиваем счётчик перед самой операцией.
+      this.shuffleCount++;
+      // Перемешиваем тайлы на поле.
+      this.shuffle();
+    } else {
+      // Достигнут предел, больше тасовать нельзя.
+      this.bus.emit("ShuffleLimitExceeded");
+    }
+  }
+
+  /**
+   * Перемешивает все тайлы board в случайном порядке.
+   * После завершения эмитится 'ShuffleDone'.
+   */
+  shuffle(): void {
+    const cfg = (this.board as unknown as { cfg: BoardConfig }).cfg;
+    const tiles: (Tile | null)[] = [];
+
+    // Считываем текущее состояние поля в плоский массив.
+    for (let y = 0; y < cfg.rows; y++) {
+      for (let x = 0; x < cfg.cols; x++) {
+        tiles.push(this.board.tileAt(new Vec2(x, y)));
+      }
+    }
+
+    // Алгоритм Фишера-Йетса для равномерного перемешивания.
+    for (let i = tiles.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [tiles[i], tiles[j]] = [tiles[j], tiles[i]];
+    }
+
+    // Записываем тайлы обратно на поле, проходя по колонкам.
+    let idx = 0;
+    for (let x = 0; x < cfg.cols; x++) {
+      for (let y = 0; y < cfg.rows; y++) {
+        this.board.setTile(new Vec2(x, y), tiles[idx++] ?? null);
+      }
+    }
+
+    // Уведомляем слушателей об окончании перетасовки.
+    this.bus.emit("ShuffleDone");
+  }
+
+  /**
+   * Сбрасывает счётчик использованных перетасовок.
+   */
+  reset(): void {
+    this.shuffleCount = 0;
+  }
+}

--- a/tests/ShuffleService.spec.ts
+++ b/tests/ShuffleService.spec.ts
@@ -1,0 +1,78 @@
+import { EventBus } from "../assets/scripts/core/EventBus";
+import { Board } from "../assets/scripts/core/board/Board";
+import { BoardSolver } from "../assets/scripts/core/board/BoardSolver";
+import { TileFactory } from "../assets/scripts/core/board/Tile";
+import { ShuffleService } from "../assets/scripts/core/board/ShuffleService";
+import { BoardConfig } from "../assets/scripts/config/BoardConfig";
+
+describe("ShuffleService", () => {
+  const cfgNoMoves: BoardConfig = {
+    cols: 1,
+    rows: 1,
+    tileSize: 1,
+    colors: ["red"],
+    superThreshold: 3,
+  };
+
+  const cfgMoves: BoardConfig = {
+    cols: 2,
+    rows: 1,
+    tileSize: 1,
+    colors: ["red"],
+    superThreshold: 3,
+  };
+
+  beforeEach(() => {
+    EventBus.removeAllListeners();
+  });
+
+  test("auto shuffles until limit then emits ShuffleLimitExceeded", () => {
+    const board = new Board(cfgNoMoves, [[TileFactory.createNormal("red")]]);
+    const solver = new BoardSolver(board);
+    const service = new ShuffleService(board, solver, EventBus, 3);
+
+    const events: string[] = [];
+    EventBus.on("AutoShuffle", () => events.push("AutoShuffle"));
+    EventBus.on("ShuffleDone", () => events.push("ShuffleDone"));
+    EventBus.on("ShuffleLimitExceeded", () => {
+      events.push("ShuffleLimitExceeded");
+    });
+
+    service.ensureMoves();
+    expect((service as unknown as { shuffleCount: number }).shuffleCount).toBe(
+      1,
+    );
+    service.ensureMoves();
+    service.ensureMoves();
+    service.ensureMoves();
+
+    expect(events).toEqual([
+      "AutoShuffle",
+      "ShuffleDone",
+      "AutoShuffle",
+      "ShuffleDone",
+      "AutoShuffle",
+      "ShuffleDone",
+      "ShuffleLimitExceeded",
+    ]);
+  });
+
+  test("does nothing when moves are available", () => {
+    const board = new Board(cfgMoves, [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+    ]);
+    const solver = new BoardSolver(board);
+    const service = new ShuffleService(board, solver, EventBus, 3);
+
+    const events: string[] = [];
+    EventBus.on("AutoShuffle", () => events.push("AutoShuffle"));
+    EventBus.on("ShuffleDone", () => events.push("ShuffleDone"));
+    EventBus.on("ShuffleLimitExceeded", () =>
+      events.push("ShuffleLimitExceeded"),
+    );
+
+    service.ensureMoves();
+
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add ShuffleService for automatic tile shuffling
- extend BoardSolver with hasMoves helper
- test ShuffleService behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68894eece33483209ed76a3ba7c08c18