### PR TITLE
Add tests for core logic

### DIFF
--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -1,0 +1,105 @@
+import { Vec2 } from "cc";
+import { EventEmitter2 } from "eventemitter2";
+
+// Create a mock event bus preserving emit functionality
+const bus = new EventEmitter2();
+const emitSpy = jest.spyOn(bus, "emit");
+
+jest.mock("../../assets/scripts/core/EventBus", () => ({
+  EventBus: bus,
+}));
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { BoardSolver } from "../../assets/scripts/core/board/BoardSolver";
+import { BoardConfig } from "../../assets/scripts/config/BoardConfig";
+
+// Common 3x3 config for tests
+const cfg: BoardConfig = {
+  cols: 3,
+  rows: 3,
+  tileSize: 1,
+  colors: ["red", "blue"],
+  superThreshold: 3,
+};
+
+function crossBoard(): Board {
+  const tiles = [
+    [
+      TileFactory.createNormal("red"),
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("red"),
+    ],
+    [
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("blue"),
+    ],
+    [
+      TileFactory.createNormal("red"),
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("red"),
+    ],
+  ];
+  return new Board(cfg, tiles);
+}
+
+beforeEach(() => {
+  emitSpy.mockClear();
+  bus.removeAllListeners();
+});
+
+// group of 5 tiles should be returned and event emitted
+it("findGroup emits GroupFound with connected tiles", () => {
+  const solver = new BoardSolver(crossBoard());
+  const res = solver.findGroup(new Vec2(1, 1));
+  expect(res).toHaveLength(5);
+  expect(emitSpy).toHaveBeenCalledWith("GroupFound", res);
+});
+
+// starting outside board returns empty without emitting
+it("findGroup on out of bounds returns empty", () => {
+  const solver = new BoardSolver(crossBoard());
+  const res = solver.findGroup(new Vec2(-1, -1));
+  expect(res).toEqual([]);
+  expect(emitSpy).not.toHaveBeenCalled();
+});
+
+// board with no adjacent colors should report no moves
+it("hasMoves detects absence of moves", () => {
+  const board = new Board(cfg, [
+    [
+      TileFactory.createNormal("red"),
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("red"),
+    ],
+    [
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("red"),
+      TileFactory.createNormal("blue"),
+    ],
+    [
+      TileFactory.createNormal("red"),
+      TileFactory.createNormal("blue"),
+      TileFactory.createNormal("red"),
+    ],
+  ]);
+  const solver = new BoardSolver(board);
+  expect(solver.hasMoves()).toBe(false);
+});
+
+// starting on empty cell should return empty
+it("returns empty when start cell has no tile", () => {
+  const board = crossBoard();
+  board.setTile(new Vec2(1, 1), null);
+  const solver = new BoardSolver(board);
+  const res = solver.findGroup(new Vec2(1, 1));
+  expect(res).toEqual([]);
+});
+
+// hasMoves positive case
+it("hasMoves detects available move", () => {
+  const board = crossBoard();
+  const solver = new BoardSolver(board);
+  expect(solver.hasMoves()).toBe(true);
+});

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -1,0 +1,146 @@
+import { Vec2 } from "cc";
+import { EventEmitter2 } from "eventemitter2";
+
+const bus = new EventEmitter2();
+const emitSpy = jest.spyOn(bus, "emit");
+
+jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));
+
+import {
+  GameStateMachine,
+  GameState,
+} from "../../assets/scripts/core/game/GameStateMachine";
+import { Board } from "../../assets/scripts/core/board/Board";
+import { BoardSolver } from "../../assets/scripts/core/board/BoardSolver";
+import { MoveExecutor } from "../../assets/scripts/core/board/MoveExecutor";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { BoardConfig } from "../../assets/scripts/config/BoardConfig";
+import { ScoreStrategyQuadratic } from "../../assets/scripts/core/rules/ScoreStrategyQuadratic";
+import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
+
+const cfg: BoardConfig = {
+  cols: 2,
+  rows: 2,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+function createFSM(target = 10, board?: Board): GameStateMachine {
+  const b =
+    board ??
+    new Board(cfg, [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+      [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+    ]);
+  const solver = new BoardSolver(b);
+  const exec = new MoveExecutor(b, bus);
+  const strategy = new ScoreStrategyQuadratic(1);
+  const tm = new TurnManager(5, bus);
+  return new GameStateMachine(bus, b, solver, exec, strategy, tm, target, 2);
+}
+
+beforeEach(() => {
+  emitSpy.mockClear();
+  bus.removeAllListeners();
+});
+
+// starting the FSM should emit initial state
+it("start emits WaitingInput", () => {
+  const fsm = createFSM();
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  expect(states).toEqual(["WaitingInput"]);
+});
+
+// selecting a group runs full move cycle
+it("group selection performs move and returns to WaitingInput", async () => {
+  const fsm = createFSM();
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("GroupSelected", new Vec2(0, 0));
+  await new Promise((r) => setImmediate(r));
+  expect(states.slice(0, 5)).toEqual([
+    "WaitingInput",
+    "ExecutingMove",
+    "TilesFalling",
+    "Filling",
+    "CheckEnd",
+  ]);
+});
+
+// easy target should lead to Win state after move
+it("wins when target score reached", async () => {
+  const fsm = createFSM(5);
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("GroupSelected", new Vec2(0, 0));
+  await new Promise((r) => setImmediate(r));
+  expect(states).toContain("Win");
+});
+
+// booster flow transitions between states
+it("handles booster activate and cancel", () => {
+  const fsm = createFSM();
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("BoosterActivated");
+  bus.emit("BoosterConsumed");
+  expect(states).toEqual(["WaitingInput", "BoosterInput", "ExecutingMove"]);
+});
+
+it("cancels booster back to WaitingInput", () => {
+  const fsm = createFSM();
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("BoosterActivated");
+  bus.emit("BoosterCancelled");
+  expect(states).toEqual(["WaitingInput", "BoosterInput", "WaitingInput"]);
+});
+
+// losing when out of turns and no moves
+it("moves to Lose when turns end", async () => {
+  const board = new Board(cfg, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+  ]);
+  const solver = new BoardSolver(board);
+  const exec = new MoveExecutor(board, bus);
+  const strategy = new ScoreStrategyQuadratic(1);
+  const tm = new TurnManager(1, bus); // single turn
+  const fsm = new GameStateMachine(
+    bus,
+    board,
+    solver,
+    exec,
+    strategy,
+    tm,
+    100,
+    0,
+  );
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("GroupSelected", new Vec2(0, 0));
+  await new Promise((r) => setImmediate(r));
+  expect(states).toContain("Lose");
+});
+
+// deadlock triggers shuffle state
+it("shuffles board when no moves left", async () => {
+  const board = new Board({ ...cfg, cols: 2, rows: 1 }, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+  ]);
+  const fsm = createFSM(100, board);
+  const states: GameState[] = [];
+  bus.on("StateChanged", (s) => states.push(s));
+  fsm.start();
+  bus.emit("GroupSelected", new Vec2(0, 0));
+  await new Promise((r) => setImmediate(r));
+  const lastTwo = states.slice(-2);
+  expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);
+});

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -1,0 +1,66 @@
+import { Vec2 } from "cc";
+import { EventEmitter2 } from "eventemitter2";
+
+const bus = new EventEmitter2();
+const emitSpy = jest.spyOn(bus, "emit");
+
+jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { MoveExecutor } from "../../assets/scripts/core/board/MoveExecutor";
+import { BoardConfig } from "../../assets/scripts/config/BoardConfig";
+
+const cfg: BoardConfig = {
+  cols: 2,
+  rows: 2,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+beforeEach(() => {
+  emitSpy.mockClear();
+  bus.removeAllListeners();
+});
+
+// normal case: commands executed and events emitted in order
+it("executes remove, fall and fill then emits MoveCompleted", async () => {
+  const board = new Board(cfg, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+  ]);
+  const executor = new MoveExecutor(board, bus);
+  const sequence: string[] = [];
+  bus.on("removeDone", () => sequence.push("removeDone"));
+  bus.on("fallDone", () => sequence.push("fallDone"));
+  bus.on("fillDone", () => sequence.push("fillDone"));
+  bus.on("MoveCompleted", () => sequence.push("MoveCompleted"));
+
+  await executor.execute([new Vec2(0, 0), new Vec2(1, 0)]);
+
+  expect(sequence).toEqual([
+    "removeDone",
+    "fallDone",
+    "fillDone",
+    "MoveCompleted",
+  ]);
+});
+
+// boundary: coordinates outside board are ignored but flow still completes
+it("ignores out of bounds tiles in group", async () => {
+  const board = new Board(cfg, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+  ]);
+  const executor = new MoveExecutor(board, bus);
+  await executor.execute([new Vec2(0, 0), new Vec2(5, 5)]);
+  expect(emitSpy).toHaveBeenLastCalledWith("MoveCompleted");
+});
+
+// error case: empty group should reject
+it("throws when group is empty", async () => {
+  const board = new Board(cfg);
+  const executor = new MoveExecutor(board, bus);
+  await expect(executor.execute([])).rejects.toThrow();
+});

--- a/__tests__/core/ScoreStrategyQuadratic.spec.ts
+++ b/__tests__/core/ScoreStrategyQuadratic.spec.ts
@@ -1,0 +1,19 @@
+import { ScoreStrategyQuadratic } from "../../assets/scripts/core/rules/ScoreStrategyQuadratic";
+
+// typical case with multiplier
+it("calculates quadratic score", () => {
+  const s = new ScoreStrategyQuadratic(2);
+  expect(s.calculate(4)).toBe(18);
+});
+
+// boundary: single tile gives zero
+it("returns zero for size one", () => {
+  const s = new ScoreStrategyQuadratic();
+  expect(s.calculate(1)).toBe(0);
+});
+
+// large group to check growth
+it("scales with square of size", () => {
+  const s = new ScoreStrategyQuadratic(1);
+  expect(s.calculate(6)).toBe(25);
+});

--- a/__tests__/core/ShuffleService.spec.ts
+++ b/__tests__/core/ShuffleService.spec.ts
@@ -1,0 +1,84 @@
+import { EventEmitter2 } from "eventemitter2";
+
+const bus = new EventEmitter2();
+const emitSpy = jest.spyOn(bus, "emit");
+
+jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { BoardSolver } from "../../assets/scripts/core/board/BoardSolver";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { ShuffleService } from "../../assets/scripts/core/board/ShuffleService";
+import { BoardConfig } from "../../assets/scripts/config/BoardConfig";
+
+const cfgSingle: BoardConfig = {
+  cols: 1,
+  rows: 1,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+const cfgPair: BoardConfig = {
+  cols: 2,
+  rows: 1,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+beforeEach(() => {
+  emitSpy.mockClear();
+  bus.removeAllListeners();
+});
+
+// when moves exist nothing happens
+it("ensureMoves does nothing when moves available", () => {
+  const board = new Board(cfgPair, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+  ]);
+  const solver = new BoardSolver(board);
+  const service = new ShuffleService(board, solver, bus, 2);
+  service.ensureMoves();
+  expect(emitSpy).not.toHaveBeenCalled();
+});
+
+// auto shuffle until limit reached
+it("auto shuffles until limit then emits ShuffleLimitExceeded", () => {
+  const board = new Board(cfgSingle, [[TileFactory.createNormal("red")]]);
+  const solver = new BoardSolver(board);
+  const service = new ShuffleService(board, solver, bus, 2);
+  service.ensureMoves();
+  service.ensureMoves();
+  service.ensureMoves();
+  expect(emitSpy.mock.calls.map((c) => c[0])).toEqual([
+    "AutoShuffle",
+    "ShuffleDone",
+    "AutoShuffle",
+    "ShuffleDone",
+    "ShuffleLimitExceeded",
+  ]);
+});
+
+// reset clears shuffle counter
+it("reset allows shuffling again", () => {
+  const board = new Board(cfgSingle, [[TileFactory.createNormal("red")]]);
+  const solver = new BoardSolver(board);
+  const service = new ShuffleService(board, solver, bus, 1);
+  service.ensureMoves();
+  service.ensureMoves();
+  emitSpy.mockClear();
+  service.reset();
+  service.ensureMoves();
+  expect(emitSpy.mock.calls[0][0]).toBe("AutoShuffle");
+});
+
+// direct shuffle mixes tiles and emits ShuffleDone
+it("shuffle performs Fisher-Yates step", () => {
+  const board = new Board(cfgPair, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
+  ]);
+  const solver = new BoardSolver(board);
+  const service = new ShuffleService(board, solver, bus, 1);
+  service.shuffle();
+  expect(emitSpy).toHaveBeenCalledWith("ShuffleDone");
+});

--- a/__tests__/core/TurnManager.spec.ts
+++ b/__tests__/core/TurnManager.spec.ts
@@ -1,0 +1,34 @@
+import { EventEmitter2 } from "eventemitter2";
+import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
+
+const bus = new EventEmitter2();
+const emitSpy = jest.spyOn(bus, "emit");
+
+beforeEach(() => {
+  emitSpy.mockClear();
+  bus.removeAllListeners();
+});
+
+// turns decrease and event emitted
+it("useTurn decreases remaining turns", () => {
+  const tm = new TurnManager(3, bus);
+  tm.useTurn();
+  tm.useTurn();
+  expect(tm.getRemaining()).toBe(1);
+  expect(emitSpy).toHaveBeenCalledTimes(2);
+});
+
+// last turn triggers OutOfTurns
+it("emits OutOfTurns when reaching zero", () => {
+  const tm = new TurnManager(1, bus);
+  let called = 0;
+  bus.on("OutOfTurns", () => called++);
+  tm.useTurn();
+  expect(called).toBe(1);
+});
+
+// starting with many turns stays positive
+it("getRemaining returns initial value", () => {
+  const tm = new TurnManager(5, bus);
+  expect(tm.getRemaining()).toBe(5);
+});


### PR DESCRIPTION
## Summary
- add new test suite under `__tests__/core` covering key classes
- verify event emission using a mocked `EventBus`
- simulate edge conditions for FSM, shuffling and scoring

## Testing
- `npm test`
- `npx jest --coverage --collectCoverageFrom="assets/scripts/core/{board/BoardSolver.ts,board/MoveExecutor.ts,board/ShuffleService.ts,game/GameStateMachine.ts,rules/ScoreStrategyQuadratic.ts,rules/TurnManager.ts}"`

------
https://chatgpt.com/codex/tasks/task_e_688950e1d5ec8320a30276f337d7526a