### PR TITLE
Add basic Menu and Game scenes

### DIFF
--- a/assets/scenes/GameScene.scene
+++ b/assets/scenes/GameScene.scene
@@ -1,0 +1,11 @@
+{
+  "name": "GameScene",
+  "canvas": {
+    "name": "Canvas",
+    "children": [
+      { "name": "TilesLayer" },
+      { "name": "FxLayer" },
+      { "name": "HudLayer" }
+    ]
+  }
+}

--- a/assets/scenes/MenuScene.scene
+++ b/assets/scenes/MenuScene.scene
@@ -1,0 +1,18 @@
+{
+  "name": "MenuScene",
+  "canvas": {
+    "name": "Canvas",
+    "children": [
+      {
+        "name": "Background",
+        "type": "Sprite"
+      },
+      {
+        "name": "PlayButton",
+        "type": "Button",
+        "label": "Play",
+        "script": "MenuController"
+      }
+    ]
+  }
+}

--- a/assets/scripts/ui/MenuController.ts
+++ b/assets/scripts/ui/MenuController.ts
@@ -1,0 +1,14 @@
+import { _decorator, Component, director } from "cc";
+const { ccclass } = _decorator;
+
+/**
+ * Controls interactions on the main menu.
+ * Attached to the Play button.
+ */
+@ccclass("MenuController")
+export class MenuController extends Component {
+  /** Loads the main GameScene when the Play button is clicked. */
+  onPlay(): void {
+    director.loadScene("GameScene");
+  }
+}

--- a/project.json
+++ b/project.json
@@ -1,0 +1,13 @@
+{
+  "scenes": [
+    {
+      "url": "db://assets/scenes/MenuScene.scene",
+      "uuid": "menu-scene"
+    },
+    {
+      "url": "db://assets/scenes/GameScene.scene",
+      "uuid": "game-scene"
+    }
+  ],
+  "launchScene": "db://assets/scenes/MenuScene.scene"
+}

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -4,4 +4,19 @@ declare module "cc" {
     x: number;
     y: number;
   }
+
+  /** Minimal stub for Cocos decorator system. */
+  export const _decorator: {
+    /** Marks a class as a Cocos component. */
+    ccclass(name?: string): ClassDecorator;
+  };
+
+  /** Base component class every behaviour derives from. */
+  export class Component {}
+
+  /** Provides scene management utilities. */
+  export const director: {
+    /** Loads a scene by its name. */
+    loadScene(name: string): void;
+  };
 }


### PR DESCRIPTION
## Summary
- scaffold MenuScene and GameScene JSON files
- include scene references in project.json
- create MenuController script to load GameScene
- extend cc.d.ts stubs with Cocos API used by new script

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889573e7e9c8320a9933dc9feebded2