### PR TITLE
Configure Canvas & Safe Area

### DIFF
--- a/assets/scenes/GameScene.scene
+++ b/assets/scenes/GameScene.scene
@@ -2,10 +2,14 @@
   "name": "GameScene",
   "canvas": {
     "name": "Canvas",
+    "fitWidth": true,
+    "fitHeight": true,
+    "referenceResolution": [540, 960],
+    "safeArea": true,
     "children": [
       { "name": "TilesLayer" },
       { "name": "FxLayer" },
-      { "name": "HudLayer" }
+      { "name": "HudLayer", "script": "SafeAreaAdjuster" }
     ]
   }
 }

--- a/assets/scenes/MenuScene.scene
+++ b/assets/scenes/MenuScene.scene
@@ -2,6 +2,10 @@
   "name": "MenuScene",
   "canvas": {
     "name": "Canvas",
+    "fitWidth": true,
+    "fitHeight": true,
+    "referenceResolution": [540, 960],
+    "safeArea": true,
     "children": [
       {
         "name": "Background",

--- a/assets/scripts/ui/SafeAreaAdjuster.ts
+++ b/assets/scripts/ui/SafeAreaAdjuster.ts
@@ -1,0 +1,43 @@
+import { _decorator, Component } from "cc";
+const { ccclass } = _decorator;
+
+declare const screen: {
+  safeArea: { x: number; y: number; width: number; height: number };
+};
+
+interface Adjustable {
+  paddingLeft: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingTop: number;
+}
+
+interface NodeWithUITransform {
+  getComponent(name: string): Adjustable | null;
+}
+
+/**
+ * Adjusts the padding of the attached UI node to match the device safe area.
+ * This ensures that on devices with notches or rounded corners the HUD
+ * elements remain fully visible.
+ *
+ * Canvas automatically scales to 540x960 while preserving aspect ratio using
+ * the Fit Width & Fit Height settings defined in the scene files. The safe
+ * area offsets are then applied here at runtime so UI widgets avoid cutouts
+ * on phones like iPhone X.
+ */
+@ccclass("SafeAreaAdjuster")
+export class SafeAreaAdjuster extends Component {
+  /** Reads screen.safeArea and applies it to the node's UITransform. */
+  start(): void {
+    const area = screen.safeArea;
+    const node = this.node as unknown as NodeWithUITransform;
+    const uiTransform = node.getComponent("UITransform");
+    if (!uiTransform || !area) return;
+
+    uiTransform.paddingLeft = area.x;
+    uiTransform.paddingRight = area.width - area.x;
+    uiTransform.paddingBottom = area.y;
+    uiTransform.paddingTop = area.height - area.y;
+  }
+}

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -12,7 +12,9 @@ declare module "cc" {
   };
 
   /** Base component class every behaviour derives from. */
-  export class Component {}
+  export class Component {
+    node: unknown;
+  }
 
   /** Provides scene management utilities. */
   export const director: {


### PR DESCRIPTION
## Summary
- set Canvas to Fit Width/Height with reference resolution
- enable safe area handling in scenes
- implement `SafeAreaAdjuster` script for HUD
- expose `node` field on the Component type stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688959dc65ec8320a46bc60d8416dda3