### PR TITLE
Implement HUD layer

### DIFF
--- a/assets/scenes/GameScene.scene
+++ b/assets/scenes/GameScene.scene
@@ -9,7 +9,23 @@
     "children": [
       { "name": "TilesLayer" },
       { "name": "FxLayer" },
-      { "name": "HudLayer", "script": "SafeAreaAdjuster" }
+      {
+        "name": "HudLayer",
+        "script": "SafeAreaAdjuster",
+        "children": [
+          { "name": "lblScore", "type": "Label", "string": "0", "align": "left-top" },
+          { "name": "lblMoves", "type": "Label", "string": "0", "align": "right-top" },
+          {
+            "name": "BoosterPanel",
+            "children": [
+              { "name": "btnBomb", "type": "Button", "label": "Bomb" },
+              { "name": "btnSwap", "type": "Button", "label": "Swap" }
+            ]
+          },
+          { "name": "btnPause", "type": "Button", "label": "≡" },
+          { "name": "Controller", "script": "HudController" }
+        ]
+      }
     ]
   }
 }

--- a/assets/scripts/ui/HudController.ts
+++ b/assets/scripts/ui/HudController.ts
@@ -1,0 +1,69 @@
+import { _decorator, Component, Label } from "cc";
+import { EventBus } from "../core/EventBus";
+const { ccclass } = _decorator;
+
+interface NodeUtils {
+  getChildByName(name: string): NodeUtils | null;
+  getComponent(name: string): unknown;
+  on(event: string, cb: () => void): void;
+  node?: NodeUtils;
+}
+
+/**
+ * Controls the Heads Up Display of the GameScene.
+ * Responsible for updating score/move counters and
+ * dispatching events when HUD buttons are pressed.
+ */
+@ccclass("HudController")
+export class HudController extends Component {
+  private lblScore: Label | null = null;
+  private lblMoves: Label | null = null;
+  private btnBomb: NodeUtils | null = null;
+  private btnSwap: NodeUtils | null = null;
+  private btnPause: NodeUtils | null = null;
+
+  /** Initializes component references and event listeners. */
+  start(): void {
+    const root = this.node as unknown as NodeUtils;
+
+    this.lblScore = root
+      .getChildByName("lblScore")
+      ?.getComponent("Label") as Label | null;
+    this.lblMoves = root
+      .getChildByName("lblMoves")
+      ?.getComponent("Label") as Label | null;
+
+    const panel = root.getChildByName("BoosterPanel") as NodeUtils | null;
+    this.btnBomb = panel
+      ?.getChildByName("btnBomb")
+      ?.getComponent("Button") as NodeUtils | null;
+    this.btnSwap = panel
+      ?.getChildByName("btnSwap")
+      ?.getComponent("Button") as NodeUtils | null;
+
+    this.btnPause = root
+      .getChildByName("btnPause")
+      ?.getComponent("Button") as NodeUtils | null;
+
+    // Update moves counter when a turn is consumed
+    EventBus.on("TurnUsed", (left: number) => {
+      if (this.lblMoves) this.lblMoves.string = String(left);
+    });
+
+    // Update score display after a turn ends
+    EventBus.on("TurnEnded", ({ score }: { score: number }) => {
+      if (this.lblScore) this.lblScore.string = String(score);
+    });
+
+    // Booster and pause button interactions
+    this.btnBomb?.node?.on("click", () => {
+      EventBus.emit("BoosterActivated", "bomb");
+    });
+    this.btnSwap?.node?.on("click", () => {
+      EventBus.emit("BoosterActivated", "swap");
+    });
+    this.btnPause?.node?.on("click", () => {
+      EventBus.emit("GamePaused");
+    });
+  }
+}

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -21,4 +21,18 @@ declare module "cc" {
     /** Loads a scene by its name. */
     loadScene(name: string): void;
   };
+
+  /** Simplified label component used to display text in the HUD. */
+  export class Label {
+    /** Text contents shown on screen. */
+    string: string;
+    /** Node the component is attached to. */
+    node: unknown;
+  }
+
+  /** Minimal clickable UI element. */
+  export class Button {
+    /** Root node this button controls. */
+    node: unknown;
+  }
 }


### PR DESCRIPTION
## Summary
- add a simple HUD controller that updates score and moves
- extend `GameScene` with HUD nodes and buttons
- stub Label and Button in `cc` type declarations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889c36d6720832092ddad428b513ebf