### PR TITLE
Add result popup prefab

### DIFF
--- a/assets/prefabs/PopupResult.prefab
+++ b/assets/prefabs/PopupResult.prefab
@@ -1,0 +1,14 @@
+{
+  "name": "PopupResult",
+  "node": {
+    "name": "PopupResult",
+    "type": "Panel",
+    "slice9": [16, 16, 16, 16],
+    "children": [
+      { "name": "lblTitle", "type": "Label", "string": "Victory!" },
+      { "name": "lblFinalScore", "type": "Label", "string": "Score: 0" },
+      { "name": "btnRestart", "type": "Button", "label": "Restart" }
+    ],
+    "script": "PopupController"
+  }
+}

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -143,6 +143,12 @@ export class GameStateMachine {
   private changeState(newState: GameState): void {
     this.state = newState;
     this.bus.emit("StateChanged", newState);
+    if (newState === "Win") {
+      this.bus.emit("GameWon", this.score);
+    }
+    if (newState === "Lose") {
+      this.bus.emit("GameLost", this.score);
+    }
   }
 
   /**

--- a/assets/scripts/ui/PopupController.ts
+++ b/assets/scripts/ui/PopupController.ts
@@ -1,0 +1,45 @@
+import { _decorator, Component, director, tween, Vec3 } from "cc";
+import { EventBus } from "../core/EventBus";
+const { ccclass } = _decorator;
+
+/**
+ * Handles showing the result popup when a game ends.
+ * The background uses a 9-sliced sprite with 16px borders so it
+ * can scale smoothly without stretching the corners.
+ */
+@ccclass("PopupController")
+export class PopupController extends Component {
+  /** Title label displaying Victory or Defeat text. */
+  lblTitle!: { string: string };
+  /** Label showing the final score amount. */
+  lblFinalScore!: { string: string };
+  /** Restart button node. */
+  btnRestart!: { node: { once: (event: string, cb: () => void) => void } };
+
+  onEnable(): void {
+    EventBus.on("GameWon", (score: number) => this.show(true, score));
+    EventBus.on("GameLost", (score: number) => this.show(false, score));
+  }
+
+  onDisable(): void {
+    EventBus.removeAllListeners("GameWon");
+    EventBus.removeAllListeners("GameLost");
+  }
+
+  /**
+   * Populates UI fields and plays a scale animation.
+   * @param win Whether the game was won
+   * @param score Final player score
+   */
+  show(win: boolean, score: number): void {
+    if (this.lblTitle) this.lblTitle.string = win ? "Victory!" : "Defeat...";
+    if (this.lblFinalScore) this.lblFinalScore.string = `Score: ${score}`;
+    if (this.btnRestart)
+      this.btnRestart.node.once("click", () => director.loadScene("MenuScene"));
+
+    (this.node as unknown as { scale: Vec3 }).scale = new Vec3(0, 0, 0);
+    tween(this.node as unknown as { scale: Vec3 })
+      .to(0.3, { scale: new Vec3(1, 1, 1) }, { easing: "backOut" })
+      .start();
+  }
+}

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -5,6 +5,35 @@ declare module "cc" {
     y: number;
   }
 
+  export class Vec3 {
+    constructor(x?: number, y?: number, z?: number);
+    x: number;
+    y: number;
+    z: number;
+  }
+
+  export class Node {
+    scale: Vec3;
+  }
+
+  export class Label {
+    string: string;
+  }
+
+  export class Button {
+    node: Node;
+    static EventType: { CLICK: string };
+  }
+
+  export function tween(target: unknown): {
+    to(
+      duration: number,
+      props: Record<string, unknown>,
+      opts?: { easing?: string },
+    ): ReturnType<typeof tween>;
+    start(): void;
+  };
+
   /** Minimal stub for Cocos decorator system. */
   export const _decorator: {
     /** Marks a class as a Cocos component. */


### PR DESCRIPTION
## Summary
- add `PopupResult` prefab with 9-sliced panel
- implement `PopupController` to show final result
- emit `GameWon` and `GameLost` events from the state machine
- extend Cocos stubs with minimal UI classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c59d79d08320b41d0a1d8fa8ba12