### PR TITLE
Add pause popup and scene controller

### DIFF
--- a/assets/prefabs/PopupPause.prefab
+++ b/assets/prefabs/PopupPause.prefab
@@ -1,0 +1,13 @@
+{
+  "name": "PopupPause",
+  "node": {
+    "name": "PopupPause",
+    "type": "Panel",
+    "slice9": [16, 16, 16, 16],
+    "children": [
+      { "name": "btnResume", "type": "Button", "label": "Resume" },
+      { "name": "btnRestart", "type": "Button", "label": "Restart" }
+    ],
+    "script": "PopupPause"
+  }
+}

--- a/assets/scenes/GameScene.scene
+++ b/assets/scenes/GameScene.scene
@@ -25,7 +25,19 @@
           { "name": "btnPause", "type": "Button", "label": "≡" },
           { "name": "Controller", "script": "HudController" }
         ]
-      }
+      },
+      {
+        "name": "PopupPause",
+        "type": "Panel",
+        "slice9": [16, 16, 16, 16],
+        "active": false,
+        "children": [
+          { "name": "btnResume", "type": "Button", "label": "Resume" },
+          { "name": "btnRestart", "type": "Button", "label": "Restart" }
+        ],
+        "script": "PopupPause"
+      },
+      { "name": "SceneController", "script": "GameSceneController" }
     ]
   }
 }

--- a/assets/scripts/ui/GameSceneController.ts
+++ b/assets/scripts/ui/GameSceneController.ts
@@ -1,0 +1,39 @@
+import { _decorator, Component, director } from "cc";
+import { EventBus } from "../core/EventBus";
+const { ccclass } = _decorator;
+
+interface NodeUtils {
+  getChildByName(name: string): NodeUtils | null;
+  getComponent(name: string): unknown;
+  node?: { active: boolean };
+}
+
+/**
+ * Handles pause/resume events for the game scene.
+ * director.pause stops the entire engine including timers and animations,
+ * while simply blocking input would let those continue running.
+ */
+@ccclass("GameSceneController")
+export class GameSceneController extends Component {
+  private popup: { node: { active: boolean } } | null = null;
+
+  start(): void {
+    const root = this.node as unknown as NodeUtils;
+    this.popup = root
+      .getChildByName("PopupPause")
+      ?.getComponent("PopupPause") as unknown as {
+      node: { active: boolean };
+    } | null;
+    if (this.popup?.node) this.popup.node.active = false;
+
+    EventBus.on("GamePaused", () => {
+      director.pause();
+      if (this.popup?.node) this.popup.node.active = true;
+    });
+
+    EventBus.on("GameResumed", () => {
+      director.resume();
+      if (this.popup?.node) this.popup.node.active = false;
+    });
+  }
+}

--- a/assets/scripts/ui/PopupPause.ts
+++ b/assets/scripts/ui/PopupPause.ts
@@ -1,0 +1,37 @@
+import { _decorator, Component, director } from "cc";
+import { EventBus } from "../core/EventBus";
+const { ccclass } = _decorator;
+
+interface NodeUtils {
+  getChildByName(name: string): NodeUtils | null;
+  getComponent(name: string): unknown;
+  on(event: string, cb: () => void): void;
+  node?: NodeUtils;
+}
+
+/**
+ * Controls the pause popup displayed when the game is paused.
+ * Emits GameResumed or reloads the scene depending on button presses.
+ */
+@ccclass("PopupPause")
+export class PopupPause extends Component {
+  private btnResume: NodeUtils | null = null;
+  private btnRestart: NodeUtils | null = null;
+
+  start(): void {
+    const root = this.node as unknown as NodeUtils;
+    this.btnResume = root
+      .getChildByName("btnResume")
+      ?.getComponent("Button") as NodeUtils | null;
+    this.btnRestart = root
+      .getChildByName("btnRestart")
+      ?.getComponent("Button") as NodeUtils | null;
+
+    this.btnResume?.node?.on("click", () => {
+      EventBus.emit("GameResumed");
+    });
+    this.btnRestart?.node?.on("click", () => {
+      director.loadScene("GameScene");
+    });
+  }
+}

--- a/tests/cc.ts
+++ b/tests/cc.ts
@@ -6,3 +6,43 @@ export class Vec2 {
     this.y = y;
   }
 }
+
+export class Vec3 {
+  x: number;
+  y: number;
+  z: number;
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}
+
+export class Node {
+  scale = new Vec3();
+  active = false;
+}
+
+export class Component {
+  node: unknown = new Node();
+}
+
+export const _decorator = {
+  ccclass: () => () => {},
+};
+
+export class Label {
+  string = "";
+  node: unknown = new Node();
+}
+
+export class Button {
+  node = new Node();
+  static EventType = { CLICK: "click" };
+}
+
+export const director = {
+  loadScene: () => {},
+  pause: () => {},
+  resume: () => {},
+};

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -14,15 +14,7 @@ declare module "cc" {
 
   export class Node {
     scale: Vec3;
-  }
-
-  export class Label {
-    string: string;
-  }
-
-  export class Button {
-    node: Node;
-    static EventType: { CLICK: string };
+    active: boolean;
   }
 
   export function tween(target: unknown): {
@@ -49,6 +41,10 @@ declare module "cc" {
   export const director: {
     /** Loads a scene by its name. */
     loadScene(name: string): void;
+    /** Pauses the entire director, halting updates. */
+    pause(): void;
+    /** Resumes updates after a pause. */
+    resume(): void;
   };
 
   /** Simplified label component used to display text in the HUD. */


### PR DESCRIPTION
## Summary
- implement pause popup prefab and controller
- add GameScene controller handling pause/resume
- extend cc stubs with pause/resume and Node active flag
- provide testing stubs for new cc features

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c89dda8c8320bb88dccfb049b92c