### PR TITLE
Switch scripts to global cc

### DIFF
--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventEmitter2 } from "eventemitter2";
 
 // Create a mock event bus preserving emit functionality
@@ -52,7 +51,7 @@ beforeEach(() => {
 // group of 5 tiles should be returned and event emitted
 it("findGroup emits GroupFound with connected tiles", () => {
   const solver = new BoardSolver(crossBoard());
-  const res = solver.findGroup(new Vec2(1, 1));
+  const res = solver.findGroup(new cc.Vec2(1, 1));
   expect(res).toHaveLength(5);
   expect(emitSpy).toHaveBeenCalledWith("GroupFound", res);
 });
@@ -60,7 +59,7 @@ it("findGroup emits GroupFound with connected tiles", () => {
 // starting outside board returns empty without emitting
 it("findGroup on out of bounds returns empty", () => {
   const solver = new BoardSolver(crossBoard());
-  const res = solver.findGroup(new Vec2(-1, -1));
+  const res = solver.findGroup(new cc.Vec2(-1, -1));
   expect(res).toEqual([]);
   expect(emitSpy).not.toHaveBeenCalled();
 });
@@ -91,9 +90,9 @@ it("hasMoves detects absence of moves", () => {
 // starting on empty cell should return empty
 it("returns empty when start cell has no tile", () => {
   const board = crossBoard();
-  board.setTile(new Vec2(1, 1), null);
+  board.setTile(new cc.Vec2(1, 1), null);
   const solver = new BoardSolver(board);
-  const res = solver.findGroup(new Vec2(1, 1));
+  const res = solver.findGroup(new cc.Vec2(1, 1));
   expect(res).toEqual([]);
 });
 

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventEmitter2 } from "eventemitter2";
 
 const bus = new EventEmitter2();
@@ -60,7 +59,7 @@ it("group selection performs move and returns to WaitingInput", async () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s));
   fsm.start();
-  bus.emit("GroupSelected", new Vec2(0, 0));
+  bus.emit("GroupSelected", new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states.slice(0, 5)).toEqual([
     "WaitingInput",
@@ -77,7 +76,7 @@ it("wins when target score reached", async () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s));
   fsm.start();
-  bus.emit("GroupSelected", new Vec2(0, 0));
+  bus.emit("GroupSelected", new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states).toContain("Win");
 });
@@ -125,7 +124,7 @@ it("moves to Lose when turns end", async () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s));
   fsm.start();
-  bus.emit("GroupSelected", new Vec2(0, 0));
+  bus.emit("GroupSelected", new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states).toContain("Lose");
 });
@@ -139,7 +138,7 @@ it("shuffles board when no moves left", async () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s));
   fsm.start();
-  bus.emit("GroupSelected", new Vec2(0, 0));
+  bus.emit("GroupSelected", new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   const lastTwo = states.slice(-2);
   expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventEmitter2 } from "eventemitter2";
 
 const bus = new EventEmitter2();
@@ -37,7 +36,7 @@ it("executes remove, fall and fill then emits MoveCompleted", async () => {
   bus.on("fillDone", () => sequence.push("fillDone"));
   bus.on("MoveCompleted", () => sequence.push("MoveCompleted"));
 
-  await executor.execute([new Vec2(0, 0), new Vec2(1, 0)]);
+  await executor.execute([new cc.Vec2(0, 0), new cc.Vec2(1, 0)]);
 
   expect(sequence).toEqual([
     "removeDone",
@@ -54,7 +53,7 @@ it("ignores out of bounds tiles in group", async () => {
     [TileFactory.createNormal("red"), TileFactory.createNormal("red")],
   ]);
   const executor = new MoveExecutor(board, bus);
-  await executor.execute([new Vec2(0, 0), new Vec2(5, 5)]);
+  await executor.execute([new cc.Vec2(0, 0), new cc.Vec2(5, 5)]);
   expect(emitSpy).toHaveBeenLastCalledWith("MoveCompleted");
 });
 

--- a/assets/scripts/core/board/Board.ts
+++ b/assets/scripts/core/board/Board.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { BoardConfig } from "../../config/BoardConfig";
 import { Tile, TileColor } from "./Tile";
 
@@ -42,7 +41,7 @@ export class Board {
    * @param p Point to test
    * @returns True if the point is inside the board
    */
-  public inBounds(p: Vec2): boolean {
+  public inBounds(p: cc.Vec2): boolean {
     return p.x >= 0 && p.y >= 0 && p.x < this.cfg.cols && p.y < this.cfg.rows;
   }
 
@@ -51,7 +50,7 @@ export class Board {
    * @param p Board coordinates
    * @returns Tile object or null if the position is empty or out of bounds
    */
-  public tileAt(p: Vec2): Tile | null {
+  public tileAt(p: cc.Vec2): Tile | null {
     return this.inBounds(p) ? this.grid[p.y][p.x] : null;
   }
 
@@ -60,7 +59,7 @@ export class Board {
    * @param p Board coordinates
    * @returns Color of tile or null when no tile is present or point is invalid
    */
-  public colorAt(p: Vec2): TileColor | null {
+  public colorAt(p: cc.Vec2): TileColor | null {
     const tile = this.tileAt(p);
     return tile ? tile.color : null;
   }
@@ -71,7 +70,7 @@ export class Board {
    * @param p Board coordinates
    * @param t Tile to place or null to clear the cell
    */
-  public setTile(p: Vec2, t: Tile | null): void {
+  public setTile(p: cc.Vec2, t: Tile | null): void {
     if (!this.inBounds(p)) {
       throw new Error(`setTile out of bounds: (${p.x}, ${p.y})`);
     }
@@ -84,13 +83,13 @@ export class Board {
    * @param p Central point
    * @returns Array of neighbouring coordinates
    */
-  public neighbors4(p: Vec2): Vec2[] {
-    const result: Vec2[] = [];
+  public neighbors4(p: cc.Vec2): cc.Vec2[] {
+    const result: cc.Vec2[] = [];
     const candidates = [
-      new Vec2(p.x, p.y - 1),
-      new Vec2(p.x + 1, p.y),
-      new Vec2(p.x, p.y + 1),
-      new Vec2(p.x - 1, p.y),
+      new cc.Vec2(p.x, p.y - 1),
+      new cc.Vec2(p.x + 1, p.y),
+      new cc.Vec2(p.x, p.y + 1),
+      new cc.Vec2(p.x - 1, p.y),
     ];
     for (const c of candidates) {
       if (this.inBounds(c)) {
@@ -104,12 +103,12 @@ export class Board {
    * Iterates over all cells of the board invoking callback for non-null tiles.
    * @param callback Function called with coordinates and tile
    */
-  public forEach(callback: (p: Vec2, t: Tile) => void): void {
+  public forEach(callback: (p: cc.Vec2, t: Tile) => void): void {
     for (let y = 0; y < this.cfg.rows; y++) {
       for (let x = 0; x < this.cfg.cols; x++) {
         const tile = this.grid[y][x];
         if (tile) {
-          callback(new Vec2(x, y), tile);
+          callback(new cc.Vec2(x, y), tile);
         }
       }
     }

--- a/assets/scripts/core/board/BoardSolver.ts
+++ b/assets/scripts/core/board/BoardSolver.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventBus } from "../EventBus";
 import { Board } from "./Board";
 
@@ -18,7 +17,7 @@ export class BoardSolver {
    * @param start Starting board coordinates
    * @returns Array of coordinates belonging to the found group
    */
-  findGroup(start: Vec2): Vec2[] {
+  findGroup(start: cc.Vec2): cc.Vec2[] {
     // Return empty when starting point is invalid or empty
     if (!this.board.inBounds(start)) {
       return [];
@@ -28,13 +27,13 @@ export class BoardSolver {
       return [];
     }
 
-    const result: Vec2[] = [];
-    const stack: Vec2[] = [start];
+    const result: cc.Vec2[] = [];
+    const stack: cc.Vec2[] = [start];
     // "visited" tracks processed cells to prevent infinite loops
     const visited = new Set<string>();
 
     while (stack.length > 0) {
-      const p = stack.pop() as Vec2;
+      const p = stack.pop() as cc.Vec2;
       const key = `${p.x},${p.y}`;
       if (visited.has(key)) continue;
       visited.add(key);

--- a/assets/scripts/core/board/MoveExecutor.ts
+++ b/assets/scripts/core/board/MoveExecutor.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "./Board";
 import { EventEmitter2 } from "eventemitter2";
 import { RemoveCommand } from "./commands/RemoveCommand";
@@ -16,7 +15,7 @@ export class MoveExecutor {
     private bus: EventEmitter2,
   ) {}
 
-  async execute(group: Vec2[]): Promise<void> {
+  async execute(group: cc.Vec2[]): Promise<void> {
     if (group.length === 0) {
       throw new Error("MoveExecutor: group is empty");
     }
@@ -29,7 +28,7 @@ export class MoveExecutor {
     // 2. Let tiles fall in affected columns
     const fallDone = this.wait("fallDone");
     new FallCommand(this.board, this.bus, dirtyCols).execute();
-    const [emptySlots] = (await fallDone) as [Vec2[]];
+    const [emptySlots] = (await fallDone) as [cc.Vec2[]];
 
     // 3. Fill empty spaces with new tiles
     const fillDone = this.wait("fillDone");

--- a/assets/scripts/core/board/ShuffleService.ts
+++ b/assets/scripts/core/board/ShuffleService.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventEmitter2 } from "eventemitter2";
 import { Board } from "./Board";
 import { BoardSolver } from "./BoardSolver";
@@ -50,7 +49,7 @@ export class ShuffleService {
     // Считываем текущее состояние поля в плоский массив.
     for (let y = 0; y < cfg.rows; y++) {
       for (let x = 0; x < cfg.cols; x++) {
-        tiles.push(this.board.tileAt(new Vec2(x, y)));
+        tiles.push(this.board.tileAt(new cc.Vec2(x, y)));
       }
     }
 
@@ -64,7 +63,7 @@ export class ShuffleService {
     let idx = 0;
     for (let x = 0; x < cfg.cols; x++) {
       for (let y = 0; y < cfg.rows; y++) {
-        this.board.setTile(new Vec2(x, y), tiles[idx++] ?? null);
+        this.board.setTile(new cc.Vec2(x, y), tiles[idx++] ?? null);
       }
     }
 

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "../Board";
 import { EventEmitter2 } from "eventemitter2";
 import { ICommand } from "./ICommand";
@@ -30,14 +29,14 @@ export class FallCommand implements ICommand {
 
     this.bus.emit("fallStart", this.columns);
 
-    const emptySlots: Vec2[] = [];
+    const emptySlots: cc.Vec2[] = [];
     const rows = this.cfg.rows;
 
     for (const x of this.columns) {
       const kept: Tile[] = [];
       // Collect existing tiles from bottom to top
       for (let y = rows - 1; y >= 0; y--) {
-        const t = this.board.tileAt(new Vec2(x, y));
+        const t = this.board.tileAt(new cc.Vec2(x, y));
         if (t) {
           kept.push(t);
         }
@@ -45,12 +44,12 @@ export class FallCommand implements ICommand {
       // Place tiles starting from bottom
       let y = rows - 1;
       for (const t of kept) {
-        this.board.setTile(new Vec2(x, y), t);
+        this.board.setTile(new cc.Vec2(x, y), t);
         y--;
       }
       // Clear remaining cells and record them as empty
       for (; y >= 0; y--) {
-        const p = new Vec2(x, y);
+        const p = new cc.Vec2(x, y);
         this.board.setTile(p, null);
         emptySlots.push(p);
       }

--- a/assets/scripts/core/board/commands/FillCommand.ts
+++ b/assets/scripts/core/board/commands/FillCommand.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "../Board";
 import { EventEmitter2 } from "eventemitter2";
 import { ICommand } from "./ICommand";
@@ -13,7 +12,7 @@ export class FillCommand implements ICommand {
   constructor(
     private board: Board,
     private bus: EventEmitter2,
-    private slots: Vec2[],
+    private slots: cc.Vec2[],
   ) {}
 
   private get cfg(): BoardConfig {

--- a/assets/scripts/core/board/commands/RemoveCommand.ts
+++ b/assets/scripts/core/board/commands/RemoveCommand.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "../Board";
 import { EventEmitter2 } from "eventemitter2";
 import { ICommand } from "./ICommand";
@@ -12,7 +11,7 @@ export class RemoveCommand implements ICommand {
   constructor(
     private board: Board,
     private bus: EventEmitter2,
-    private group: Vec2[],
+    private group: cc.Vec2[],
   ) {}
 
   async execute(): Promise<void> {

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -9,7 +9,6 @@ export type GameState =
   | "Win"
   | "Lose";
 
-import { Vec2 } from "cc";
 import { EventEmitter2 } from "eventemitter2";
 import { Board } from "../board/Board";
 import { BoardSolver } from "../board/BoardSolver";
@@ -45,7 +44,7 @@ export class GameStateMachine {
    * Subscribe to relevant events and enter the initial WaitingInput state.
    */
   start(): void {
-    this.bus.on("GroupSelected", (p: Vec2) => this.onGroupSelected(p));
+    this.bus.on("GroupSelected", (p: cc.Vec2) => this.onGroupSelected(p));
     this.bus.on("BoosterActivated", () => this.onBoosterActivated());
     this.bus.on("BoosterConsumed", () => this.onBoosterConsumed());
     this.bus.on("BoosterCancelled", () => this.onBoosterCancelled());
@@ -57,7 +56,7 @@ export class GameStateMachine {
    * Handles selection of a group by the player.
    * Ignored unless the machine awaits input.
    */
-  private onGroupSelected(start: Vec2): void {
+  private onGroupSelected(start: cc.Vec2): void {
     if (this.state !== "WaitingInput") {
       // Ignore input while another action is executing
       return;
@@ -176,7 +175,7 @@ export class GameStateMachine {
     const tiles: ReturnType<typeof this.board.tileAt>[] = [];
     for (let y = 0; y < cfg.rows; y++) {
       for (let x = 0; x < cfg.cols; x++) {
-        tiles.push(this.board.tileAt(new Vec2(x, y)));
+        tiles.push(this.board.tileAt(new cc.Vec2(x, y)));
       }
     }
     // Fisher–Yates shuffle
@@ -187,7 +186,7 @@ export class GameStateMachine {
     let idx = 0;
     for (let y = 0; y < cfg.rows; y++) {
       for (let x = 0; x < cfg.cols; x++) {
-        this.board.setTile(new Vec2(x, y), tiles[idx++] ?? null);
+        this.board.setTile(new cc.Vec2(x, y), tiles[idx++] ?? null);
       }
     }
   }

--- a/assets/scripts/ui/GameSceneController.ts
+++ b/assets/scripts/ui/GameSceneController.ts
@@ -1,6 +1,5 @@
-import { _decorator, Component, director } from "cc";
 import { EventBus } from "../core/EventBus";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 interface NodeUtils {
   getChildByName(name: string): NodeUtils | null;
@@ -14,7 +13,7 @@ interface NodeUtils {
  * while simply blocking input would let those continue running.
  */
 @ccclass("GameSceneController")
-export class GameSceneController extends Component {
+export class GameSceneController extends cc.Component {
   private popup: { node: { active: boolean } } | null = null;
 
   start(): void {
@@ -27,12 +26,12 @@ export class GameSceneController extends Component {
     if (this.popup?.node) this.popup.node.active = false;
 
     EventBus.on("GamePaused", () => {
-      director.pause();
+      cc.director.pause();
       if (this.popup?.node) this.popup.node.active = true;
     });
 
     EventBus.on("GameResumed", () => {
-      director.resume();
+      cc.director.resume();
       if (this.popup?.node) this.popup.node.active = false;
     });
   }

--- a/assets/scripts/ui/HudController.ts
+++ b/assets/scripts/ui/HudController.ts
@@ -1,6 +1,5 @@
-import { _decorator, Component, Label, tween } from "cc";
 import { EventBus } from "../core/EventBus";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 interface NodeUtils {
   getChildByName(name: string): NodeUtils | null;
@@ -21,9 +20,9 @@ const pulse = {};
  * dispatching events when HUD buttons are pressed.
  */
 @ccclass("HudController")
-export class HudController extends Component {
-  private lblScore: Label | null = null;
-  private lblMoves: Label | null = null;
+export class HudController extends cc.Component {
+  private lblScore: cc.Label | null = null;
+  private lblMoves: cc.Label | null = null;
   private btnBomb: NodeUtils | null = null;
   private btnSwap: NodeUtils | null = null;
   private btnPause: NodeUtils | null = null;
@@ -34,10 +33,10 @@ export class HudController extends Component {
 
     this.lblScore = root
       .getChildByName("lblScore")
-      ?.getComponent("Label") as Label | null;
+      ?.getComponent("Label") as cc.Label | null;
     this.lblMoves = root
       .getChildByName("lblMoves")
-      ?.getComponent("Label") as Label | null;
+      ?.getComponent("Label") as cc.Label | null;
 
     const panel = root.getChildByName("BoosterPanel") as NodeUtils | null;
     this.btnBomb = panel
@@ -69,7 +68,7 @@ export class HudController extends Component {
       const data = { value: startVal };
       EventBus.emit("AnimationStarted", "score-tween");
       // Tween over half a second using an ease-out curve for smooth feel
-      tween(data).to(0.5, { value: score }, { easing: "quadOut" }).start();
+      cc.tween(data).to(0.5, { value: score }, { easing: "quadOut" }).start();
       const id = setInterval(() => {
         if (this.lblScore)
           this.lblScore.string = String(Math.round(data.value));

--- a/assets/scripts/ui/MenuController.ts
+++ b/assets/scripts/ui/MenuController.ts
@@ -1,14 +1,13 @@
-import { _decorator, Component, director } from "cc";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 /**
  * Controls interactions on the main menu.
  * Attached to the Play button.
  */
 @ccclass("MenuController")
-export class MenuController extends Component {
+export class MenuController extends cc.Component {
   /** Loads the main GameScene when the Play button is clicked. */
   onPlay(): void {
-    director.loadScene("GameScene");
+    cc.director.loadScene("GameScene");
   }
 }

--- a/assets/scripts/ui/PopupController.ts
+++ b/assets/scripts/ui/PopupController.ts
@@ -1,6 +1,5 @@
-import { _decorator, Component, director, tween, Vec3 } from "cc";
 import { EventBus } from "../core/EventBus";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 /**
  * Handles showing the result popup when a game ends.
@@ -8,7 +7,7 @@ const { ccclass } = _decorator;
  * can scale smoothly without stretching the corners.
  */
 @ccclass("PopupController")
-export class PopupController extends Component {
+export class PopupController extends cc.Component {
   /** Title label displaying Victory or Defeat text. */
   lblTitle!: { string: string };
   /** Label showing the final score amount. */
@@ -35,11 +34,13 @@ export class PopupController extends Component {
     if (this.lblTitle) this.lblTitle.string = win ? "Victory!" : "Defeat...";
     if (this.lblFinalScore) this.lblFinalScore.string = `Score: ${score}`;
     if (this.btnRestart)
-      this.btnRestart.node.once("click", () => director.loadScene("MenuScene"));
+      this.btnRestart.node.once("click", () =>
+        cc.director.loadScene("MenuScene"),
+      );
 
-    (this.node as unknown as { scale: Vec3 }).scale = new Vec3(0, 0, 0);
-    tween(this.node as unknown as { scale: Vec3 })
-      .to(0.3, { scale: new Vec3(1, 1, 1) }, { easing: "backOut" })
+    (this.node as unknown as { scale: cc.Vec3 }).scale = new cc.Vec3(0, 0, 0);
+    cc.tween(this.node as unknown as { scale: cc.Vec3 })
+      .to(0.3, { scale: new cc.Vec3(1, 1, 1) }, { easing: "backOut" })
       .start();
   }
 }

--- a/assets/scripts/ui/PopupPause.ts
+++ b/assets/scripts/ui/PopupPause.ts
@@ -1,6 +1,5 @@
-import { _decorator, Component, director } from "cc";
 import { EventBus } from "../core/EventBus";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 interface NodeUtils {
   getChildByName(name: string): NodeUtils | null;
@@ -14,7 +13,7 @@ interface NodeUtils {
  * Emits GameResumed or reloads the scene depending on button presses.
  */
 @ccclass("PopupPause")
-export class PopupPause extends Component {
+export class PopupPause extends cc.Component {
   private btnResume: NodeUtils | null = null;
   private btnRestart: NodeUtils | null = null;
 
@@ -31,7 +30,7 @@ export class PopupPause extends Component {
       EventBus.emit("GameResumed");
     });
     this.btnRestart?.node?.on("click", () => {
-      director.loadScene("GameScene");
+      cc.director.loadScene("GameScene");
     });
   }
 }

--- a/assets/scripts/ui/SafeAreaAdjuster.ts
+++ b/assets/scripts/ui/SafeAreaAdjuster.ts
@@ -1,5 +1,4 @@
-import { _decorator, Component } from "cc";
-const { ccclass } = _decorator;
+const { ccclass } = cc._decorator;
 
 declare const screen: {
   safeArea: { x: number; y: number; width: number; height: number };
@@ -27,7 +26,7 @@ interface NodeWithUITransform {
  * on phones like iPhone X.
  */
 @ccclass("SafeAreaAdjuster")
-export class SafeAreaAdjuster extends Component {
+export class SafeAreaAdjuster extends cc.Component {
   /** Reads screen.safeArea and applies it to the node's UITransform. */
   start(): void {
     const area = screen.safeArea;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,8 +4,5 @@ module.exports = {
   preset: 'ts-jest',
   // Run tests in Node environment
   testEnvironment: 'node',
-  // Redirect imports of the cocos Vec2 module to a local stub
-  moduleNameMapper: {
-    '^cc$': '<rootDir>/tests/cc.ts',
-  },
+  setupFiles: ['<rootDir>/tests/setupGlobals.ts'],
 };

--- a/tests/Board.spec.ts
+++ b/tests/Board.spec.ts
@@ -1,34 +1,33 @@
-import { Board } from '../assets/scripts/core/board/Board';
-import { Vec2 } from 'cc';
-import { BoardConfig } from '../assets/scripts/config/BoardConfig';
+import { Board } from "../assets/scripts/core/board/Board";
+import { BoardConfig } from "../assets/scripts/config/BoardConfig";
 
-describe('Board', () => {
+describe("Board", () => {
   const cfg: BoardConfig = {
     cols: 3,
     rows: 3,
     tileSize: 1,
-    colors: ['red'],
+    colors: ["red"],
     superThreshold: 3,
   };
   const board = new Board(cfg);
 
-  test('inBounds works', () => {
-    expect(board.inBounds(new Vec2(0, 0))).toBe(true);
-    expect(board.inBounds(new Vec2(2, 2))).toBe(true);
-    expect(board.inBounds(new Vec2(3, 0))).toBe(false);
-    expect(board.inBounds(new Vec2(-1, 0))).toBe(false);
+  test("inBounds works", () => {
+    expect(board.inBounds(new cc.Vec2(0, 0))).toBe(true);
+    expect(board.inBounds(new cc.Vec2(2, 2))).toBe(true);
+    expect(board.inBounds(new cc.Vec2(3, 0))).toBe(false);
+    expect(board.inBounds(new cc.Vec2(-1, 0))).toBe(false);
   });
 
-  test('neighbors4 respects borders', () => {
-    const center = board.neighbors4(new Vec2(1, 1));
+  test("neighbors4 respects borders", () => {
+    const center = board.neighbors4(new cc.Vec2(1, 1));
     expect(center).toEqual([
-      new Vec2(1, 0),
-      new Vec2(2, 1),
-      new Vec2(1, 2),
-      new Vec2(0, 1),
+      new cc.Vec2(1, 0),
+      new cc.Vec2(2, 1),
+      new cc.Vec2(1, 2),
+      new cc.Vec2(0, 1),
     ]);
 
-    const corner = board.neighbors4(new Vec2(0, 0));
-    expect(corner).toEqual([new Vec2(1, 0), new Vec2(0, 1)]);
+    const corner = board.neighbors4(new cc.Vec2(0, 0));
+    expect(corner).toEqual([new cc.Vec2(1, 0), new cc.Vec2(0, 1)]);
   });
 });

--- a/tests/BoardGenerator.spec.ts
+++ b/tests/BoardGenerator.spec.ts
@@ -1,28 +1,27 @@
-import { BoardGenerator } from '../assets/scripts/core/board/BoardGenerator';
-import { Vec2 } from 'cc';
-import { BoardConfig } from '../assets/scripts/config/BoardConfig';
+import { BoardGenerator } from "../assets/scripts/core/board/BoardGenerator";
+import { BoardConfig } from "../assets/scripts/config/BoardConfig";
 
-describe('BoardGenerator', () => {
+describe("BoardGenerator", () => {
   const cfg: BoardConfig = {
     cols: 4,
     rows: 4,
     tileSize: 1,
-    colors: ['red', 'blue'],
+    colors: ["red", "blue"],
     superThreshold: 3,
   };
   const gen = new BoardGenerator();
 
-  test('generated board has correct size and no dead start', () => {
+  test("generated board has correct size and no dead start", () => {
     const board = gen.generate(cfg);
     // check dimensions
-    expect(board.inBounds(new Vec2(cfg.cols - 1, cfg.rows - 1))).toBe(true);
-    expect(board.inBounds(new Vec2(cfg.cols, cfg.rows - 1))).toBe(false);
+    expect(board.inBounds(new cc.Vec2(cfg.cols - 1, cfg.rows - 1))).toBe(true);
+    expect(board.inBounds(new cc.Vec2(cfg.cols, cfg.rows - 1))).toBe(false);
 
     // ensure at least one adjacent pair of same color exists
     let hasMove = false;
     for (let y = 0; y < cfg.rows; y++) {
       for (let x = 0; x < cfg.cols; x++) {
-        const p = new Vec2(x, y);
+        const p = new cc.Vec2(x, y);
         const tile = board.tileAt(p);
         if (!tile) continue;
         for (const n of board.neighbors4(p)) {

--- a/tests/BoardSolver.spec.ts
+++ b/tests/BoardSolver.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "../assets/scripts/core/board/Board";
 import { TileFactory } from "../assets/scripts/core/board/Tile";
 import { BoardSolver } from "../assets/scripts/core/board/BoardSolver";
@@ -37,7 +36,7 @@ describe("BoardSolver.findGroup", () => {
   test("returns connected same-color tiles for center", () => {
     const board = createCrossBoard();
     const solver = new BoardSolver(board);
-    const group = solver.findGroup(new Vec2(1, 1));
+    const group = solver.findGroup(new cc.Vec2(1, 1));
     const coords = group.map((p) => [p.x, p.y]);
     expect(coords).toHaveLength(5);
     expect(coords).toEqual(
@@ -54,7 +53,7 @@ describe("BoardSolver.findGroup", () => {
   test("returns empty array when start is out of bounds", () => {
     const board = createCrossBoard();
     const solver = new BoardSolver(board);
-    const group = solver.findGroup(new Vec2(-1, -1));
+    const group = solver.findGroup(new cc.Vec2(-1, -1));
     expect(group).toEqual([]);
   });
 });

--- a/tests/GameStateMachine.spec.ts
+++ b/tests/GameStateMachine.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { EventBus } from "../assets/scripts/core/EventBus";
 import {
   GameStateMachine,
@@ -61,7 +60,7 @@ describe("GameStateMachine", () => {
     const states: GameState[] = [];
     EventBus.on("StateChanged", (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     expect(states.slice(0, 5)).toEqual([
       "WaitingInput",
@@ -77,7 +76,7 @@ describe("GameStateMachine", () => {
     const states: GameState[] = [];
     EventBus.on("StateChanged", (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     expect(states).toContain("Win");
   });
@@ -95,7 +94,7 @@ describe("GameStateMachine", () => {
     const states: GameState[] = [];
     EventBus.on("StateChanged", (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new Vec2(0, 0));
+    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     const lastTwo = states.slice(-2);
     expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);
@@ -106,8 +105,8 @@ describe("GameStateMachine", () => {
     const states: GameState[] = [];
     EventBus.on("StateChanged", (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new Vec2(0, 0));
-    EventBus.emit("GroupSelected", new Vec2(0, 1));
+    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
+    EventBus.emit("GroupSelected", new cc.Vec2(0, 1));
     expect(states.filter((s) => s === "ExecutingMove")).toHaveLength(1);
   });
 });

--- a/tests/MoveExecutor.spec.ts
+++ b/tests/MoveExecutor.spec.ts
@@ -1,4 +1,3 @@
-import { Vec2 } from "cc";
 import { Board } from "../assets/scripts/core/board/Board";
 import { BoardConfig } from "../assets/scripts/config/BoardConfig";
 import { TileFactory } from "../assets/scripts/core/board/Tile";
@@ -32,7 +31,7 @@ describe("MoveExecutor", () => {
     EventBus.on("fillDone", () => events.push("fillDone"));
     EventBus.on("MoveCompleted", () => events.push("MoveCompleted"));
 
-    await executor.execute([new Vec2(0, 1), new Vec2(1, 1)]);
+    await executor.execute([new cc.Vec2(0, 1), new cc.Vec2(1, 1)]);
 
     expect(events).toEqual([
       "removeDone",

--- a/tests/setupGlobals.ts
+++ b/tests/setupGlobals.ts
@@ -1,0 +1,2 @@
+import * as cocos from "./cc";
+(globalThis as unknown as { cc: typeof cocos }).cc = cocos;

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -1,23 +1,23 @@
-declare module "cc" {
-  export class Vec2 {
+declare namespace cc {
+  class Vec2 {
     constructor(x?: number, y?: number);
     x: number;
     y: number;
   }
 
-  export class Vec3 {
+  class Vec3 {
     constructor(x?: number, y?: number, z?: number);
     x: number;
     y: number;
     z: number;
   }
 
-  export class Node {
+  class Node {
     scale: Vec3;
     active: boolean;
   }
 
-  export function tween(target: unknown): {
+  function tween(target: unknown): {
     to(
       duration: number,
       props: Record<string, unknown>,
@@ -26,38 +26,30 @@ declare module "cc" {
     start(): void;
   };
 
-  /** Minimal stub for Cocos decorator system. */
-  export const _decorator: {
-    /** Marks a class as a Cocos component. */
+  const _decorator: {
     ccclass(name?: string): ClassDecorator;
   };
 
-  /** Base component class every behaviour derives from. */
-  export class Component {
+  class Component {
     node: unknown;
   }
 
-  /** Provides scene management utilities. */
-  export const director: {
-    /** Loads a scene by its name. */
+  const director: {
     loadScene(name: string): void;
-    /** Pauses the entire director, halting updates. */
     pause(): void;
-    /** Resumes updates after a pause. */
     resume(): void;
   };
 
-  /** Simplified label component used to display text in the HUD. */
-  export class Label {
-    /** Text contents shown on screen. */
+  class Label {
     string: string;
-    /** Node the component is attached to. */
     node: unknown;
   }
 
-  /** Minimal clickable UI element. */
-  export class Button {
-    /** Root node this button controls. */
+  class Button {
     node: unknown;
   }
+}
+
+declare module "cc" {
+  export = cc;
 }


### PR DESCRIPTION
## Summary
- replace all imports from 'cc' with usage of global `cc`
- adjust engine types to provide global `cc` namespace and module
- update unit tests for global `cc`
- configure Jest to set up global `cc`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889e0a103f08320ba233f5fd3d09201