### PR TITLE
Fix ccclass warnings and transpile target

### DIFF
--- a/assets/scripts/ui/GameSceneController.ts
+++ b/assets/scripts/ui/GameSceneController.ts
@@ -12,7 +12,7 @@ interface NodeUtils {
  * director.pause stops the entire engine including timers and animations,
  * while simply blocking input would let those continue running.
  */
-@ccclass("GameSceneController")
+@ccclass("")
 export class GameSceneController extends cc.Component {
   private popup: { node: { active: boolean } } | null = null;
 

--- a/assets/scripts/ui/HudController.ts
+++ b/assets/scripts/ui/HudController.ts
@@ -19,7 +19,7 @@ const pulse = {};
  * Responsible for updating score/move counters and
  * dispatching events when HUD buttons are pressed.
  */
-@ccclass("HudController")
+@ccclass("")
 export class HudController extends cc.Component {
   private lblScore: cc.Label | null = null;
   private lblMoves: cc.Label | null = null;

--- a/assets/scripts/ui/MenuController.ts
+++ b/assets/scripts/ui/MenuController.ts
@@ -4,7 +4,7 @@ const { ccclass } = cc._decorator;
  * Controls interactions on the main menu.
  * Attached to the Play button.
  */
-@ccclass("MenuController")
+@ccclass("")
 export class MenuController extends cc.Component {
   /** Loads the main GameScene when the Play button is clicked. */
   onPlay(): void {

--- a/assets/scripts/ui/PopupController.ts
+++ b/assets/scripts/ui/PopupController.ts
@@ -6,7 +6,7 @@ const { ccclass } = cc._decorator;
  * The background uses a 9-sliced sprite with 16px borders so it
  * can scale smoothly without stretching the corners.
  */
-@ccclass("PopupController")
+@ccclass("")
 export class PopupController extends cc.Component {
   /** Title label displaying Victory or Defeat text. */
   lblTitle!: { string: string };

--- a/assets/scripts/ui/PopupPause.ts
+++ b/assets/scripts/ui/PopupPause.ts
@@ -12,7 +12,7 @@ interface NodeUtils {
  * Controls the pause popup displayed when the game is paused.
  * Emits GameResumed or reloads the scene depending on button presses.
  */
-@ccclass("PopupPause")
+@ccclass("")
 export class PopupPause extends cc.Component {
   private btnResume: NodeUtils | null = null;
   private btnRestart: NodeUtils | null = null;

--- a/assets/scripts/ui/SafeAreaAdjuster.ts
+++ b/assets/scripts/ui/SafeAreaAdjuster.ts
@@ -25,7 +25,7 @@ interface NodeWithUITransform {
  * area offsets are then applied here at runtime so UI widgets avoid cutouts
  * on phones like iPhone X.
  */
-@ccclass("SafeAreaAdjuster")
+@ccclass("")
 export class SafeAreaAdjuster extends cc.Component {
   /** Reads screen.safeArea and applies it to the node's UITransform. */
   start(): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    // Target modern JavaScript output
-    "target": "ESNext",
+    // Target an older ECMAScript version so optional chaining is transpiled
+    "target": "ES2018",
     // Use CommonJS modules so Node can run the code
     "module": "commonjs",
     // Enable strict type checking for better code quality


### PR DESCRIPTION
## Summary
- lower TS target to transpile optional chaining so the generated JS doesn't contain it
- remove explicit component names from decorators and call `ccclass("")`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889eb5c3a9883208a65a3610e485461