### PR TITLE
Implement bomb booster and command

### DIFF
--- a/__tests__/core/BombBooster.spec.ts
+++ b/__tests__/core/BombBooster.spec.ts
@@ -1,0 +1,53 @@
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { BombBooster } from "../../assets/scripts/core/boosters/BombBooster";
+import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+
+const cfg: BoardConfig = {
+  cols: 3,
+  rows: 3,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+describe("BombBooster", () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+
+  beforeEach(() => {
+    emitSpy.mockClear();
+    bus.removeAllListeners();
+  });
+
+  it("consumes charge and runs BombCommand on click", async () => {
+    const tiles = Array.from({ length: 3 }, () =>
+      Array.from({ length: 3 }, () => TileFactory.createNormal("red")),
+    );
+    const board = new Board(cfg, tiles);
+    const booster = new BombBooster(board, bus, 1, 1);
+    const events: string[] = [];
+    bus.on("MoveCompleted", () => events.push("MoveCompleted"));
+    booster.start();
+
+    bus.emit("GroupSelected", new cc.Vec2(1, 1));
+    await new Promise((r) => setImmediate(r));
+
+    expect(booster.charges).toBe(0);
+    expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "bomb");
+    expect(events).toEqual(["MoveCompleted"]);
+    // neighbors cleared
+    for (let x = 0; x < 3; x++) {
+      for (let y = 0; y < 3; y++) {
+        const p = new cc.Vec2(x, y);
+        if (x === 1 && y === 1) {
+          expect(board.tileAt(p)).not.toBeNull();
+        } else {
+          expect(board.tileAt(p)).toBeNull();
+        }
+      }
+    }
+  });
+});

--- a/__tests__/core/BombCommand.spec.ts
+++ b/__tests__/core/BombCommand.spec.ts
@@ -1,0 +1,50 @@
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { BombCommand } from "../../assets/scripts/core/board/commands/BombCommand";
+import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+
+const cfg: BoardConfig = {
+  cols: 3,
+  rows: 3,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+describe("BombCommand", () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+
+  beforeEach(() => {
+    emitSpy.mockClear();
+    bus.removeAllListeners();
+  });
+
+  it("removes tiles in radius and emits events", async () => {
+    const tiles = Array.from({ length: 3 }, () =>
+      Array.from({ length: 3 }, () => TileFactory.createNormal("red")),
+    );
+    const board = new Board(cfg, tiles);
+    const cmd = new BombCommand(board, new cc.Vec2(1, 1), 1, bus);
+    const seq: string[] = [];
+    bus.on("removeDone", () => seq.push("removeDone"));
+    bus.on("MoveCompleted", () => seq.push("MoveCompleted"));
+
+    await cmd.execute();
+
+    expect(seq).toEqual(["removeDone", "MoveCompleted"]);
+    // center tile remains, остальные восемь должны быть пустыми
+    for (let x = 0; x < 3; x++) {
+      for (let y = 0; y < 3; y++) {
+        const p = new cc.Vec2(x, y);
+        if (x === 1 && y === 1) {
+          expect(board.tileAt(p)).not.toBeNull();
+        } else {
+          expect(board.tileAt(p)).toBeNull();
+        }
+      }
+    }
+  });
+});

--- a/assets/scripts/core/board/commands/BombCommand.ts
+++ b/assets/scripts/core/board/commands/BombCommand.ts
@@ -1,0 +1,44 @@
+import { Board } from "../Board";
+import { EventBus } from "../../../infrastructure/EventBus";
+import { ICommand } from "./ICommand";
+import { RemoveCommand } from "./RemoveCommand";
+
+/**
+ * Схлопывает все тайлы в радиусе R от center.
+ */
+export class BombCommand implements ICommand {
+  constructor(
+    private board: Board,
+    private center: cc.Vec2,
+    private radius: number,
+    private bus: EventBus,
+  ) {}
+
+  async execute(): Promise<void> {
+    // Собираем координаты вокруг центра, исключая саму клетку.
+    // Перебираем квадрат [-R,R] и используем условие
+    // max(|dx|,|dy|) <= R, что соответствует радиусу по Чебышёву.
+    // Точки за границами поля игнорируются.
+    const group: cc.Vec2[] = [];
+    for (let dx = -this.radius; dx <= this.radius; dx++) {
+      for (let dy = -this.radius; dy <= this.radius; dy++) {
+        // Используем метрику Чебышёва: max(|dx|,|dy|) <= R
+        if (Math.max(Math.abs(dx), Math.abs(dy)) <= this.radius) {
+          if (dx === 0 && dy === 0) continue; // центр не трогаем
+          const p = new cc.Vec2(this.center.x + dx, this.center.y + dy);
+          // Координаты за пределами поля игнорируются
+          if (this.board.inBounds(p)) group.push(p);
+        }
+      }
+    }
+
+    // Ждём завершения RemoveCommand
+    await new Promise<void>((resolve) => {
+      this.bus.once("removeDone", () => resolve());
+      void new RemoveCommand(this.board, this.bus, group).execute();
+    });
+
+    // Отправляем событие о завершении применения бустера
+    this.bus.emit("MoveCompleted");
+  }
+}

--- a/assets/scripts/core/boosters/BombBooster.ts
+++ b/assets/scripts/core/boosters/BombBooster.ts
@@ -1,0 +1,40 @@
+import { Booster } from "./Booster";
+import { Board } from "../board/Board";
+import { EventBus } from "../../infrastructure/EventBus";
+import { BombCommand } from "../board/commands/BombCommand";
+
+/**
+ * Бомба: при активации ждёт клика,
+ * затем создаёт BombCommand.
+ */
+export class BombBooster implements Booster {
+  id = "bomb";
+  charges: number;
+  constructor(
+    private board: Board,
+    private bus: EventBus,
+    charges: number,
+    private radius: number,
+  ) {
+    this.charges = charges;
+  }
+
+  canActivate(): boolean {
+    return this.charges > 0;
+  }
+
+  start(): void {
+    // Подписываемся на единичный выбор клетки. После клика расходуем заряд
+    // и запускаем команду бомбы. Используем once, чтобы автоматически
+    // снять обработчик после первого срабатывания.
+    this.bus.once("GroupSelected", (pos: unknown) => {
+      if (this.charges <= 0) return;
+      const p = pos as cc.Vec2;
+      this.charges--;
+      // уведомляем систему, что заряд израсходован
+      this.bus.emit("BoosterConsumed", this.id);
+      // выполняем команду бомбы асинхронно
+      void new BombCommand(this.board, p, this.radius, this.bus).execute();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `BombBooster` class handling a single click and spending charges
- add `BombCommand` to remove tiles in a Chebyshev radius
- test the new booster and command

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a3064e53c83208132cc07ce27fad2