### PR TITLE
Add teleport booster

### DIFF
--- a/__tests__/core/SwapCommand.spec.ts
+++ b/__tests__/core/SwapCommand.spec.ts
@@ -1,0 +1,44 @@
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { SwapCommand } from "../../assets/scripts/core/board/commands/SwapCommand";
+import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+
+describe("SwapCommand", () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+
+  beforeEach(() => {
+    emitSpy.mockClear();
+    bus.removeAllListeners();
+  });
+
+  const cfg: BoardConfig = {
+    cols: 2,
+    rows: 1,
+    tileSize: 1,
+    colors: ["red", "blue"],
+    superThreshold: 3,
+  };
+
+  it("swaps tiles and emits SwapDone", async () => {
+    const board = new Board(cfg, [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+    ]);
+    const cmd = new SwapCommand(
+      board,
+      new cc.Vec2(0, 0),
+      new cc.Vec2(1, 0),
+      bus,
+    );
+    const seq: string[] = [];
+    bus.on("SwapDone", () => seq.push("SwapDone"));
+
+    await cmd.execute();
+
+    expect(board.tileAt(new cc.Vec2(0, 0))?.color).toBe("blue");
+    expect(board.tileAt(new cc.Vec2(1, 0))?.color).toBe("red");
+    expect(seq).toEqual(["SwapDone"]);
+  });
+});

--- a/__tests__/core/TeleportBooster.spec.ts
+++ b/__tests__/core/TeleportBooster.spec.ts
@@ -1,0 +1,71 @@
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+
+import { Board } from "../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { TeleportBooster } from "../../assets/scripts/core/boosters/TeleportBooster";
+import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+
+describe("TeleportBooster", () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+
+  beforeEach(() => {
+    emitSpy.mockClear();
+    bus.removeAllListeners();
+  });
+
+  const cfg2x2: BoardConfig = {
+    cols: 2,
+    rows: 2,
+    tileSize: 1,
+    colors: ["red", "blue"],
+    superThreshold: 3,
+  };
+
+  it("consumes charge when swap creates moves", async () => {
+    const board = new Board(cfg2x2, [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+      [TileFactory.createNormal("blue"), TileFactory.createNormal("red")],
+    ]);
+    const booster = new TeleportBooster(board, bus, 1);
+    const seq: string[] = [];
+    bus.on("SwapDone", () => seq.push("SwapDone"));
+    bus.on("BoosterConsumed", () => seq.push("BoosterConsumed"));
+
+    booster.start();
+    bus.emit("GroupSelected", new cc.Vec2(1, 0));
+    bus.emit("GroupSelected", new cc.Vec2(1, 1));
+    await new Promise((r) => setImmediate(r));
+
+    expect(booster.charges).toBe(0);
+    expect(seq).toEqual(["SwapDone", "BoosterConsumed"]);
+    expect(board.colorAt(new cc.Vec2(1, 0))).toBe("red");
+    expect(board.colorAt(new cc.Vec2(1, 1))).toBe("blue");
+  });
+
+  it("does not consume charge when no moves after swap", async () => {
+    const cfg: BoardConfig = {
+      cols: 2,
+      rows: 1,
+      tileSize: 1,
+      colors: ["red", "blue"],
+      superThreshold: 3,
+    };
+    const board = new Board(cfg, [
+      [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+    ]);
+    const booster = new TeleportBooster(board, bus, 1);
+    const events: string[] = [];
+    bus.on("SwapCancelled", () => events.push("SwapCancelled"));
+
+    booster.start();
+    bus.emit("GroupSelected", new cc.Vec2(0, 0));
+    bus.emit("GroupSelected", new cc.Vec2(1, 0));
+    await new Promise((r) => setImmediate(r));
+
+    expect(booster.charges).toBe(1);
+    expect(events).toEqual(["SwapCancelled"]);
+    expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
+    expect(board.colorAt(new cc.Vec2(1, 0))).toBe("blue");
+  });
+});

--- a/assets/scripts/core/board/commands/SwapCommand.ts
+++ b/assets/scripts/core/board/commands/SwapCommand.ts
@@ -1,0 +1,26 @@
+import { Board } from "../Board";
+import { EventBus } from "../../../infrastructure/EventBus";
+import { ICommand } from "./ICommand";
+
+/**
+ * Swaps tiles at two positions on the board and notifies listeners.
+ */
+export class SwapCommand implements ICommand {
+  constructor(
+    private board: Board,
+    private a: cc.Vec2,
+    private b: cc.Vec2,
+    private bus: EventBus,
+  ) {}
+
+  async execute(): Promise<void> {
+    if (!this.board.inBounds(this.a) || !this.board.inBounds(this.b)) {
+      throw new Error("SwapCommand: coordinates out of bounds");
+    }
+    const tA = this.board.tileAt(this.a);
+    const tB = this.board.tileAt(this.b);
+    this.board.setTile(this.a, tB);
+    this.board.setTile(this.b, tA);
+    this.bus.emit("SwapDone");
+  }
+}


### PR DESCRIPTION
## Summary
- implement TeleportBooster
- implement SwapCommand
- add unit tests for the new booster and command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a33b195f48320802e0ba5af83ab20