### PR TITLE
Implement super tile expansion in BoardSolver

### DIFF
--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -7,7 +7,7 @@ const emitSpy = jest.spyOn(bus, "emit");
 jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));
 
 import { Board } from "../../assets/scripts/core/board/Board";
-import { TileFactory } from "../../assets/scripts/core/board/Tile";
+import { TileFactory, TileKind } from "../../assets/scripts/core/board/Tile";
 import { BoardSolver } from "../../assets/scripts/core/board/BoardSolver";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 
@@ -99,4 +99,45 @@ it("hasMoves detects available move", () => {
   const board = crossBoard();
   const solver = new BoardSolver(board);
   expect(solver.hasMoves()).toBe(true);
+});
+
+// super tile expansions
+it("expands group for SuperRow", () => {
+  const cfg5: BoardConfig = {
+    cols: 5,
+    rows: 5,
+    tileSize: 1,
+    colors: ["red", "blue"],
+    superThreshold: 3,
+  };
+  const tiles = Array.from({ length: 5 }, () =>
+    Array.from({ length: 5 }, () => TileFactory.createNormal("blue")),
+  );
+  const tile = TileFactory.createNormal("red");
+  tile.kind = TileKind.SuperRow;
+  tiles[0][2] = tile;
+  const board = new Board(cfg5, tiles);
+  const solver = new BoardSolver(board);
+  const res = solver.findGroup(new cc.Vec2(2, 0));
+  expect(res).toHaveLength(5);
+});
+
+it("expands group for SuperClear", () => {
+  const cfg5: BoardConfig = {
+    cols: 5,
+    rows: 5,
+    tileSize: 1,
+    colors: ["red", "blue"],
+    superThreshold: 3,
+  };
+  const tiles = Array.from({ length: 5 }, () =>
+    Array.from({ length: 5 }, () => TileFactory.createNormal("blue")),
+  );
+  const tile = TileFactory.createNormal("red");
+  tile.kind = TileKind.SuperClear;
+  tiles[0][0] = tile;
+  const board = new Board(cfg5, tiles);
+  const solver = new BoardSolver(board);
+  const res = solver.findGroup(new cc.Vec2(0, 0));
+  expect(res).toHaveLength(cfg5.cols * cfg5.rows);
 });

--- a/assets/scripts/core/board/BoardSolver.ts
+++ b/assets/scripts/core/board/BoardSolver.ts
@@ -1,11 +1,64 @@
 import { EventBus } from "../EventBus";
 import { Board } from "./Board";
+import { Tile, TileKind } from "./Tile";
+import { BoardConfig } from "../../config/ConfigLoader";
 
 /**
  * Provides algorithms for analyzing the board state.
  */
 export class BoardSolver {
   constructor(private board: Board) {}
+
+  /**
+   * Expands removal area when a super tile is part of a group.
+   * Each branch covers a specific {@link TileKind}.
+   * A Set is not used here because the caller performs deduplication.
+   */
+  expandGroupForSuper(tile: Tile, pos: cc.Vec2): cc.Vec2[] {
+    const cfg = (this.board as unknown as { cfg: BoardConfig }).cfg;
+    switch (tile.kind) {
+      case TileKind.SuperRow:
+        // All cells of the same row are affected. Duplicates are avoided
+        // by the caller using a Set for the final group.
+        return Array.from(
+          { length: cfg.cols },
+          (_, x) => new cc.Vec2(x, pos.y),
+        );
+      case TileKind.SuperCol:
+        // Entire column is removed regardless of color.
+        return Array.from(
+          { length: cfg.rows },
+          (_, y) => new cc.Vec2(pos.x, y),
+        );
+      case TileKind.SuperBomb: {
+        // Radius-1 Chebyshev neighbourhood around the center.
+        const radius = 1;
+        const cells: cc.Vec2[] = [];
+        for (let dx = -radius; dx <= radius; dx++) {
+          for (let dy = -radius; dy <= radius; dy++) {
+            if (Math.max(Math.abs(dx), Math.abs(dy)) <= radius) {
+              const p = new cc.Vec2(pos.x + dx, pos.y + dy);
+              if (this.board.inBounds(p)) cells.push(p);
+            }
+          }
+        }
+        return cells;
+      }
+      case TileKind.SuperClear: {
+        // Every tile on the board will be removed.
+        const cells: cc.Vec2[] = [];
+        for (let y = 0; y < cfg.rows; y++) {
+          for (let x = 0; x < cfg.cols; x++) {
+            cells.push(new cc.Vec2(x, y));
+          }
+        }
+        return cells;
+      }
+      default:
+        // Normal tiles do not expand the group.
+        return [pos];
+    }
+  }
 
   /**
    * Finds all coordinates of tiles connected to the starting point
@@ -22,34 +75,65 @@ export class BoardSolver {
     if (!this.board.inBounds(start)) {
       return [];
     }
-    const startColor = this.board.colorAt(start);
-    if (!startColor) {
+    const startTile = this.board.tileAt(start);
+    if (!startTile) {
       return [];
     }
 
-    const result: cc.Vec2[] = [];
-    const stack: cc.Vec2[] = [start];
-    // "visited" tracks processed cells to prevent infinite loops
-    const visited = new Set<string>();
+    const startColor = startTile.color;
 
-    while (stack.length > 0) {
-      const p = stack.pop() as cc.Vec2;
+    // First, collect all connected tiles of the same color.
+    const colorVisited = new Set<string>();
+    const colorStack: cc.Vec2[] = [start];
+    const baseGroup: cc.Vec2[] = [];
+
+    while (colorStack.length > 0) {
+      const p = colorStack.pop() as cc.Vec2;
       const key = `${p.x},${p.y}`;
-      if (visited.has(key)) continue;
-      visited.add(key);
+      if (colorVisited.has(key)) continue;
+      colorVisited.add(key);
 
       if (this.board.colorAt(p) !== startColor) continue;
 
-      result.push(p);
-      // Only 4-directional neighbors are used because diagonal tiles
-      // are not considered adjacent in this game.
+      baseGroup.push(p);
+      // Diagonal tiles are ignored to match game rules.
       for (const n of this.board.neighbors4(p)) {
         const nKey = `${n.x},${n.y}`;
-        if (!visited.has(nKey)) {
-          stack.push(n);
+        if (!colorVisited.has(nKey)) {
+          colorStack.push(n);
         }
       }
     }
+
+    // Prepare final set and queue of super tiles to expand.
+    const resultSet = new Set<string>(baseGroup.map((p) => `${p.x},${p.y}`));
+    const superQueue = baseGroup.filter((p) => {
+      const t = this.board.tileAt(p);
+      return t !== null && t.kind !== TileKind.Normal;
+    });
+
+    // Process super tiles one by one adding their affected cells.
+    while (superQueue.length > 0) {
+      const p = superQueue.pop() as cc.Vec2;
+      const tile = this.board.tileAt(p);
+      if (!tile) continue;
+      for (const extra of this.expandGroupForSuper(tile, p)) {
+        const k = `${extra.x},${extra.y}`;
+        if (!resultSet.has(k)) {
+          resultSet.add(k);
+          const t = this.board.tileAt(extra);
+          if (t && t.kind !== TileKind.Normal) {
+            // Queue additional super tiles to trigger chain reactions.
+            superQueue.push(extra);
+          }
+        }
+      }
+    }
+
+    const result = Array.from(resultSet).map((k) => {
+      const [x, y] = k.split(",").map(Number);
+      return new cc.Vec2(x, y);
+    });
 
     // Notify listeners that a group has been found
     EventBus.emit("GroupFound", result);


### PR DESCRIPTION
## Summary
- extend `BoardSolver` with `expandGroupForSuper` to generate affected cells
- update group finding algorithm to trigger super tile effects and support chain reactions
- test new behaviour of `BoardSolver` with `SuperRow` and `SuperClear` tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5519f9c48320830f93021fb52d48