### PR TITLE
Integrate booster mode into FSM

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,3 +22,21 @@ classDiagram
 The `BoardGenerator` class uses `BoardConfig` to create a `Board` filled
 with `Tile` instances. It ensures the generated board always has at least one
 possible move by regenerating up to ten times if necessary.
+
+## Game Loop
+
+The finite state machine drives the core gameplay. User input is processed in
+`WaitingInput` and, when a booster is activated, in the dedicated
+`BoosterInput` state. The diagram below shows how booster related transitions
+tie into the main loop.
+
+```mermaid
+stateDiagram-v2
+  WaitingInput --> BoosterInput: on 'BoosterActivated'
+  BoosterInput --> ExecutingMove: on 'BoosterConsumed'
+  BoosterInput --> WaitingInput: on 'BoosterCancelled'
+```
+
+After a move or booster action completes in `ExecutingMove` the machine
+continues through tile falling and filling before returning to
+`WaitingInput` or ending the game.

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -85,7 +85,8 @@ it("handles booster activate and cancel", () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("BoosterActivated");
+  // activation now passes booster id
+  bus.emit("BoosterActivated", "bomb");
   bus.emit("BoosterConsumed");
   expect(states).toEqual(["WaitingInput", "BoosterInput", "ExecutingMove"]);
 });
@@ -95,7 +96,8 @@ it("cancels booster back to WaitingInput", () => {
   const states: GameState[] = [];
   bus.on("StateChanged", (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("BoosterActivated");
+  // include id to match BoosterService API
+  bus.emit("BoosterActivated", "bomb");
   bus.emit("BoosterCancelled");
   expect(states).toEqual(["WaitingInput", "BoosterInput", "WaitingInput"]);
 });


### PR DESCRIPTION
## Summary
- document the booster input state in architecture docs
- test GameStateMachine booster flow with explicit booster id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a641612b483209e9b7f8eb2d5e0bf