### PR TITLE
Add booster and super tile unit tests

### DIFF
--- a/__tests__/core/boosters/BoardSolverSuper.spec.ts
+++ b/__tests__/core/boosters/BoardSolverSuper.spec.ts
@@ -1,0 +1,43 @@
+import { Board } from "../../../assets/scripts/core/board/Board";
+import { TileFactory, TileKind } from "../../../assets/scripts/core/board/Tile";
+import { BoardSolver } from "../../../assets/scripts/core/board/BoardSolver";
+import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+
+const cfg: BoardConfig = {
+  cols: 5,
+  rows: 5,
+  tileSize: 1,
+  colors: ["red", "blue"],
+  superThreshold: 3,
+};
+
+// Проверяем расширение групп для всех типов супер‑тайлов
+it("expandGroupForSuper handles all kinds", () => {
+  const board = new Board(cfg);
+  const solver = new BoardSolver(board);
+
+  const rowTile = TileFactory.createNormal("red");
+  rowTile.kind = TileKind.SuperRow;
+  expect(solver.expandGroupForSuper(rowTile, new cc.Vec2(2, 3))).toEqual(
+    Array.from({ length: cfg.cols }, (_, x) => new cc.Vec2(x, 3)),
+  );
+
+  const colTile = TileFactory.createNormal("red");
+  colTile.kind = TileKind.SuperCol;
+  expect(solver.expandGroupForSuper(colTile, new cc.Vec2(4, 1))).toEqual(
+    Array.from({ length: cfg.rows }, (_, y) => new cc.Vec2(4, y)),
+  );
+
+  const bombTile = TileFactory.createNormal("red");
+  bombTile.kind = TileKind.SuperBomb;
+  const bombRes = solver.expandGroupForSuper(bombTile, new cc.Vec2(2, 2));
+  expect(bombRes).toHaveLength(9);
+  expect(bombRes).toContainEqual(new cc.Vec2(1, 1));
+  expect(bombRes).toContainEqual(new cc.Vec2(3, 3));
+
+  const clearTile = TileFactory.createNormal("red");
+  clearTile.kind = TileKind.SuperClear;
+  expect(solver.expandGroupForSuper(clearTile, new cc.Vec2(0, 0))).toHaveLength(
+    cfg.cols * cfg.rows,
+  );
+});

--- a/__tests__/core/boosters/BombBooster.spec.ts
+++ b/__tests__/core/boosters/BombBooster.spec.ts
@@ -1,0 +1,56 @@
+import { EventTarget } from "../../../tests/cc";
+jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
+  return {
+    EventBus: class MockBus extends EventTarget {
+      once(event: string, cb: (...args: unknown[]) => void): void {
+        const wrapper = (...args: unknown[]) => {
+          this.off(event, wrapper);
+          cb(...args);
+        };
+        this.on(event, wrapper);
+      }
+    },
+  };
+});
+
+import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
+import { Board } from "../../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../../assets/scripts/core/board/Tile";
+import { BombBooster } from "../../../assets/scripts/core/boosters/BombBooster";
+import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+
+const cfg: BoardConfig = {
+  cols: 3,
+  rows: 3,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+};
+
+// Проверяем расход заряда и радиус действия бомбы
+it("consumes charge and clears R-zone", async () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+  const tiles = Array.from({ length: 3 }, () =>
+    Array.from({ length: 3 }, () => TileFactory.createNormal("red")),
+  );
+  const board = new Board(cfg, tiles);
+  const booster = new BombBooster(board, bus, 1, 1);
+
+  booster.start();
+  bus.emit("GroupSelected", new cc.Vec2(1, 1));
+  await new Promise((r) => setImmediate(r));
+
+  expect(booster.charges).toBe(0);
+  expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "bomb");
+  for (let x = 0; x < 3; x++) {
+    for (let y = 0; y < 3; y++) {
+      const p = new cc.Vec2(x, y);
+      if (x === 1 && y === 1) {
+        expect(board.tileAt(p)).not.toBeNull();
+      } else {
+        expect(board.tileAt(p)).toBeNull();
+      }
+    }
+  }
+});

--- a/__tests__/core/boosters/SuperTileFactory.spec.ts
+++ b/__tests__/core/boosters/SuperTileFactory.spec.ts
@@ -1,0 +1,24 @@
+import { SuperTileFactory } from "../../../assets/scripts/core/boosters/SuperTileFactory";
+import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+import { TileKind } from "../../../assets/scripts/core/board/Tile";
+
+const cfg: BoardConfig = {
+  cols: 1,
+  rows: 1,
+  tileSize: 1,
+  colors: ["red"],
+  superThreshold: 3,
+  rngSeed: "seed",
+};
+
+// При одинаковом seed последовательность типов детерминирована
+it("produces deterministic sequence with same seed", () => {
+  const a = new SuperTileFactory(cfg);
+  const b = new SuperTileFactory(cfg);
+  const seqA = [a.make(), a.make(), a.make()];
+  const seqB = [b.make(), b.make(), b.make()];
+  expect(seqA).toEqual(seqB);
+  for (const k of seqA) {
+    expect(k).not.toBe(TileKind.Normal);
+  }
+});

--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -1,0 +1,82 @@
+import { EventTarget } from "../../../tests/cc";
+jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
+  return {
+    EventBus: class MockBus extends EventTarget {
+      once(event: string, cb: (...args: unknown[]) => void): void {
+        const wrapper = (...args: unknown[]) => {
+          this.off(event, wrapper);
+          cb(...args);
+        };
+        this.on(event, wrapper);
+      }
+    },
+  };
+});
+
+import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
+import { Board } from "../../../assets/scripts/core/board/Board";
+import { TileFactory } from "../../../assets/scripts/core/board/Tile";
+import { TeleportBooster } from "../../../assets/scripts/core/boosters/TeleportBooster";
+import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+
+const cfg2x2: BoardConfig = {
+  cols: 2,
+  rows: 2,
+  tileSize: 1,
+  colors: ["red", "blue"],
+  superThreshold: 3,
+};
+
+// Swap происходит и заряд тратится, если после обмена есть ходы
+it("consumes charge on successful swap", async () => {
+  const bus = new EventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+  const board = new Board(cfg2x2, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+    [TileFactory.createNormal("blue"), TileFactory.createNormal("red")],
+  ]);
+  const booster = new TeleportBooster(board, bus, 1);
+  const seq: string[] = [];
+  bus.on("SwapDone", () => seq.push("SwapDone"));
+  bus.on("BoosterConsumed", () => seq.push("BoosterConsumed"));
+
+  booster.start();
+  bus.emit("GroupSelected", new cc.Vec2(1, 0));
+  bus.emit("GroupSelected", new cc.Vec2(1, 1));
+  await new Promise((r) => setImmediate(r));
+
+  expect(booster.charges).toBe(0);
+  expect(seq).toEqual(["SwapDone", "BoosterConsumed"]);
+  expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "teleport");
+  expect(board.colorAt(new cc.Vec2(1, 0))).toBe("red");
+  expect(board.colorAt(new cc.Vec2(1, 1))).toBe("blue");
+});
+
+// Когда после обмена нет ходов, заряд не тратится, а событие SwapCancelled
+// уведомляет о возврате
+it("cancels swap when no moves available", async () => {
+  const bus = new EventBus();
+  const board = new Board(
+    {
+      cols: 2,
+      rows: 1,
+      tileSize: 1,
+      colors: ["red", "blue"],
+      superThreshold: 3,
+    },
+    [[TileFactory.createNormal("red"), TileFactory.createNormal("blue")]],
+  );
+  const booster = new TeleportBooster(board, bus, 1);
+  const events: string[] = [];
+  bus.on("SwapCancelled", () => events.push("SwapCancelled"));
+
+  booster.start();
+  bus.emit("GroupSelected", new cc.Vec2(0, 0));
+  bus.emit("GroupSelected", new cc.Vec2(1, 0));
+  await new Promise((r) => setImmediate(r));
+
+  expect(booster.charges).toBe(1);
+  expect(events).toEqual(["SwapCancelled"]);
+  expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
+  expect(board.colorAt(new cc.Vec2(1, 0))).toBe("blue");
+});


### PR DESCRIPTION
## Summary
- add BombBooster, TeleportBooster and SuperTileFactory tests under `core/boosters`
- check BoardSolver super-tile expansion for all kinds

## Testing
- `npm test`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a6a955168832082f87773f8b81607