### PR TITLE
Implement GameBoardController

### DIFF
--- a/assets/scripts/core/board/Board.ts
+++ b/assets/scripts/core/board/Board.ts
@@ -34,6 +34,16 @@ export class Board {
     }
   }
 
+  /** Number of rows in the board. */
+  public get rows(): number {
+    return this.cfg.rows;
+  }
+
+  /** Number of columns in the board. */
+  public get cols(): number {
+    return this.cfg.cols;
+  }
+
   /**
    * Checks whether a point lies within board boundaries.
    * Coordinates are zero-based and inclusive on the lower bound but exclusive

--- a/assets/scripts/infrastructure/EventBus.ts
+++ b/assets/scripts/infrastructure/EventBus.ts
@@ -1,0 +1,1 @@
+export { EventBus } from "../core/EventBus";

--- a/assets/scripts/ui/controllers/GameBoardController.ts
+++ b/assets/scripts/ui/controllers/GameBoardController.ts
@@ -1,0 +1,68 @@
+const { ccclass, property } = cc._decorator;
+
+import { Board } from "../../core/board/Board";
+import { BoardGenerator } from "../../core/board/BoardGenerator";
+import { loadBoardConfig } from "../../config/ConfigLoader";
+import TileView from "../views/TileView";
+
+@ccclass("GameBoardController")
+export default class GameBoardController extends cc.Component {
+  /** Prefab used to instantiate tile nodes. */
+  @property(cc.Prefab)
+  tilePrefab!: cc.Prefab;
+  /** Parent node for all tile instances. */
+  @property(cc.Node)
+  tilesLayer!: cc.Node;
+
+  /** Board model generated on load. */
+  private board!: Board;
+  /** Matrix of view components mirroring board state. */
+  private tileViews: TileView[][] = [];
+
+  /**
+   * Generates the game board when this controller loads.
+   *
+   * 1. Loads the board configuration from storage.
+   * 2. Uses {@link BoardGenerator} to create a board model.
+   * 3. Spawns tile prefabs for every cell and stores their views.
+   */
+  onLoad(): void {
+    // 1) Загрузить конфиг
+    const cfg = loadBoardConfig();
+    // 2) Сгенерировать Board
+    this.board = new BoardGenerator().generate(cfg);
+    // 3) Спавнить по каждой клетке
+    this.spawnAllTiles();
+  }
+
+  /**
+   * Instantiates tile prefabs for each board cell and saves TileView references.
+   */
+  private spawnAllTiles(): void {
+    for (let r = 0; r < this.board.rows; r++) {
+      this.tileViews[r] = [];
+      for (let c = 0; c < this.board.cols; c++) {
+        const tileData = this.board.tileAt(new cc.Vec2(c, r))!;
+        const node = cc.instantiate(this.tilePrefab);
+        node.parent = this.tilesLayer;
+        // позиционируем точно как в Core
+        node.setPosition(this.computePos(c, r));
+        // сохраняем TileView для обновлений
+        const view = node.getComponent(TileView) as TileView;
+        view.apply(tileData);
+        this.tileViews[r][c] = view;
+      }
+    }
+  }
+
+  /**
+   * Computes node position from column and row indices.
+   * Uses board size and configured tile size to match the core model.
+   */
+  private computePos(col: number, row: number): cc.Vec2 {
+    const size = loadBoardConfig().tileSize;
+    const x = (col - this.board.cols / 2 + 0.5) * size;
+    const y = (this.board.rows / 2 - row - 0.5) * size;
+    return cc.v2(x, y);
+  }
+}

--- a/assets/scripts/ui/views/TileView.ts
+++ b/assets/scripts/ui/views/TileView.ts
@@ -1,0 +1,20 @@
+const { ccclass, property } = cc._decorator;
+import type { Tile } from "../../core/board/Tile";
+
+@ccclass("TileView")
+export default class TileView extends cc.Component {
+  /** Sprite component displaying tile graphics. */
+  @property(cc.Sprite)
+  sprite!: cc.Sprite;
+
+  /**
+   * Applies tile data to this view.
+   * Currently sets the node name to the tile color so tests can inspect it.
+   */
+  apply(tile: Tile): void {
+    // In a real project we would map the tile color to a sprite frame.
+    // For the simplified environment we store the color on the node name.
+    // This helps verify correctness without engine specific assets.
+    (this.node as unknown as { name: string }).name = tile.color;
+  }
+}


### PR DESCRIPTION
## Summary
- export EventBus from infrastructure module
- expose rows/cols getters on Board model
- implement TileView component to display tile data
- implement GameBoardController to spawn board tiles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a74d60a4c83208689a70fb5215f96