### PR TITLE
Support board tile dimensions

### DIFF
--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -15,7 +15,8 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 3,
   rows: 3,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red", "blue"],
   superThreshold: 3,
 };
@@ -106,7 +107,8 @@ it("expands group for SuperRow", () => {
   const cfg5: BoardConfig = {
     cols: 5,
     rows: 5,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };
@@ -126,7 +128,8 @@ it("expands group for SuperClear", () => {
   const cfg5: BoardConfig = {
     cols: 5,
     rows: 5,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };

--- a/__tests__/core/BombBooster.spec.ts
+++ b/__tests__/core/BombBooster.spec.ts
@@ -8,7 +8,8 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 3,
   rows: 3,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/BombCommand.spec.ts
+++ b/__tests__/core/BombCommand.spec.ts
@@ -8,7 +8,8 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 3,
   rows: 3,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -18,7 +18,8 @@ import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
 const cfg: BoardConfig = {
   cols: 2,
   rows: 2,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -11,7 +11,8 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 2,
   rows: 2,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/ShuffleService.spec.ts
+++ b/__tests__/core/ShuffleService.spec.ts
@@ -12,14 +12,16 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 const cfgSingle: BoardConfig = {
   cols: 1,
   rows: 1,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };
 const cfgPair: BoardConfig = {
   cols: 2,
   rows: 1,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/SuperTileFactory.spec.ts
+++ b/__tests__/core/SuperTileFactory.spec.ts
@@ -5,7 +5,8 @@ import { TileKind } from "../../assets/scripts/core/board/Tile";
 const cfg: BoardConfig = {
   cols: 1,
   rows: 1,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
   rngSeed: "test-seed",

--- a/__tests__/core/SwapCommand.spec.ts
+++ b/__tests__/core/SwapCommand.spec.ts
@@ -17,7 +17,8 @@ describe("SwapCommand", () => {
   const cfg: BoardConfig = {
     cols: 2,
     rows: 1,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };

--- a/__tests__/core/TeleportBooster.spec.ts
+++ b/__tests__/core/TeleportBooster.spec.ts
@@ -17,7 +17,8 @@ describe("TeleportBooster", () => {
   const cfg2x2: BoardConfig = {
     cols: 2,
     rows: 2,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };
@@ -47,7 +48,8 @@ describe("TeleportBooster", () => {
     const cfg: BoardConfig = {
       cols: 2,
       rows: 1,
-      tileSize: 1,
+      tileWidth: 1,
+      tileHeight: 1,
       colors: ["red", "blue"],
       superThreshold: 3,
     };

--- a/__tests__/core/boosters/BoardSolverSuper.spec.ts
+++ b/__tests__/core/boosters/BoardSolverSuper.spec.ts
@@ -6,7 +6,8 @@ import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 5,
   rows: 5,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red", "blue"],
   superThreshold: 3,
 };

--- a/__tests__/core/boosters/BombBooster.spec.ts
+++ b/__tests__/core/boosters/BombBooster.spec.ts
@@ -22,7 +22,8 @@ import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 3,
   rows: 3,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
 };

--- a/__tests__/core/boosters/SuperTileFactory.spec.ts
+++ b/__tests__/core/boosters/SuperTileFactory.spec.ts
@@ -5,7 +5,8 @@ import { TileKind } from "../../../assets/scripts/core/board/Tile";
 const cfg: BoardConfig = {
   cols: 1,
   rows: 1,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red"],
   superThreshold: 3,
   rngSeed: "seed",

--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -22,7 +22,8 @@ import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
 const cfg2x2: BoardConfig = {
   cols: 2,
   rows: 2,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red", "blue"],
   superThreshold: 3,
 };
@@ -60,7 +61,8 @@ it("cancels swap when no moves available", async () => {
     {
       cols: 2,
       rows: 1,
-      tileSize: 1,
+      tileWidth: 1,
+      tileHeight: 1,
       colors: ["red", "blue"],
       superThreshold: 3,
     },

--- a/assets/scripts/config/ConfigLoader.ts
+++ b/assets/scripts/config/ConfigLoader.ts
@@ -5,7 +5,8 @@
 export interface BoardConfig {
   cols: number; // сколько колонок на поле
   rows: number; // сколько строк на поле
-  tileSize: number; // размер одного тайла в пикселях
+  tileWidth: number; // ширина одного тайла в пикселях
+  tileHeight: number; // высота одного тайла в пикселях
   colors: string[]; // допустимые цвета тайлов
   superThreshold: number; // размер группы для супер-тайла
   rngSeed?: string; // необязательно: фиксированный seed
@@ -15,7 +16,8 @@ export interface BoardConfig {
 export const DefaultBoard: BoardConfig = {
   cols: 9, // классическая ширина
   rows: 11, // и высота
-  tileSize: 100, // под размеры подготовленных спрайтов
+  tileWidth: 100, // под размеры подготовленных спрайтов
+  tileHeight: 100,
   colors: ["red", "blue", "green", "yellow", "purple"],
   superThreshold: 5,
 };
@@ -32,8 +34,16 @@ export function loadBoardConfig(): BoardConfig {
   }
   try {
     // объединяем сохранённые поля с настройками по умолчанию
-    const parsed = JSON.parse(raw) as Partial<BoardConfig>;
-    return Object.assign({}, DefaultBoard, parsed);
+    // поддерживая старое поле tileSize при наличии
+    const parsed = JSON.parse(raw) as Partial<
+      BoardConfig & { tileSize?: number }
+    >;
+    const combined = Object.assign({}, DefaultBoard, parsed);
+    if (typeof parsed.tileSize === "number") {
+      combined.tileWidth = parsed.tileSize;
+      combined.tileHeight = parsed.tileSize;
+    }
+    return combined;
   } catch {
     // если JSON битый, не ломаем игру
     return DefaultBoard;

--- a/assets/scripts/ui/controllers/GameBoardController.ts
+++ b/assets/scripts/ui/controllers/GameBoardController.ts
@@ -85,9 +85,9 @@ export default class GameBoardController extends cc.Component {
    * Uses board size and configured tile size to match the core model.
    */
   private computePos(col: number, row: number): cc.Vec2 {
-    const size = loadBoardConfig().tileSize;
-    const x = (col - this.board.cols / 2 + 0.5) * size;
-    const y = (this.board.rows / 2 - row - 0.5) * size;
+    const cfg = loadBoardConfig();
+    const x = (col - this.board.cols / 2 + 0.5) * cfg.tileWidth;
+    const y = (this.board.rows / 2 - row - 0.5) * cfg.tileHeight;
     return cc.v2(x, y);
   }
 

--- a/tests/Board.spec.ts
+++ b/tests/Board.spec.ts
@@ -5,7 +5,8 @@ describe("Board", () => {
   const cfg: BoardConfig = {
     cols: 3,
     rows: 3,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red"],
     superThreshold: 3,
   };

--- a/tests/BoardGenerator.spec.ts
+++ b/tests/BoardGenerator.spec.ts
@@ -5,7 +5,8 @@ describe("BoardGenerator", () => {
   const cfg: BoardConfig = {
     cols: 4,
     rows: 4,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };

--- a/tests/BoardSolver.spec.ts
+++ b/tests/BoardSolver.spec.ts
@@ -6,7 +6,8 @@ import { BoardConfig } from "../assets/scripts/config/ConfigLoader";
 const cfg: BoardConfig = {
   cols: 3,
   rows: 3,
-  tileSize: 1,
+  tileWidth: 1,
+  tileHeight: 1,
   colors: ["red", "blue", "green"],
   superThreshold: 3,
 };

--- a/tests/GameBoardController.spec.ts
+++ b/tests/GameBoardController.spec.ts
@@ -17,7 +17,8 @@ describe("GameBoardController", () => {
   const cfg: BoardConfig = {
     cols: 2,
     rows: 2,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red", "blue"],
     superThreshold: 3,
   };

--- a/tests/GameStateMachine.spec.ts
+++ b/tests/GameStateMachine.spec.ts
@@ -15,7 +15,8 @@ describe("GameStateMachine", () => {
   const cfg: BoardConfig = {
     cols: 2,
     rows: 2,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red"],
     superThreshold: 3,
   };
@@ -85,7 +86,8 @@ describe("GameStateMachine", () => {
     const singleCfg: BoardConfig = {
       cols: 1,
       rows: 1,
-      tileSize: 1,
+      tileWidth: 1,
+      tileHeight: 1,
       colors: ["red"],
       superThreshold: 3,
     };

--- a/tests/MoveExecutor.spec.ts
+++ b/tests/MoveExecutor.spec.ts
@@ -8,7 +8,8 @@ describe("MoveExecutor", () => {
   const cfg: BoardConfig = {
     cols: 2,
     rows: 2,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red"],
     superThreshold: 3,
   };

--- a/tests/ShuffleService.spec.ts
+++ b/tests/ShuffleService.spec.ts
@@ -9,7 +9,8 @@ describe("ShuffleService", () => {
   const cfgNoMoves: BoardConfig = {
     cols: 1,
     rows: 1,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red"],
     superThreshold: 3,
   };
@@ -17,7 +18,8 @@ describe("ShuffleService", () => {
   const cfgMoves: BoardConfig = {
     cols: 2,
     rows: 1,
-    tileSize: 1,
+    tileWidth: 1,
+    tileHeight: 1,
     colors: ["red"],
     superThreshold: 3,
   };


### PR DESCRIPTION
## Summary
- support rectangular tiles in board config
- adjust board controller positioning
- update tests for new width/height settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b35d8d2a08320877213317817e85d