### PR TITLE
Centralize event names

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,3 +44,4 @@ continues through tile falling and filling before returning to
 ### Event flow
 
 Components communicate via the global event bus. All event names are centralized in [`EventNames.ts`](assets/scripts/core/events/EventNames.ts).
+The bus keeps an internal registry of subscribers and logs a warning when events fire without any listeners.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,3 +40,7 @@ stateDiagram-v2
 After a move or booster action completes in `ExecutingMove` the machine
 continues through tile falling and filling before returning to
 `WaitingInput` or ending the game.
+
+### Event flow
+
+Components communicate via the global event bus. All event names are centralized in [`EventNames.ts`](assets/scripts/core/events/EventNames.ts).

--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -1,7 +1,7 @@
-import { EventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 // Create a mock event bus preserving emit functionality
-const bus = new EventBus();
+const bus = new InfrastructureEventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));

--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -1,7 +1,7 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
 // Create a mock event bus preserving emit functionality
-const bus = new ExtendedEventTarget();
+const bus = new EventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 jest.mock("../../assets/scripts/core/EventBus", () => ({ EventBus: bus }));

--- a/__tests__/core/BoardSolver.spec.ts
+++ b/__tests__/core/BoardSolver.spec.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { EventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 // Create a mock event bus preserving emit functionality
 const bus = new EventBus();

--- a/__tests__/core/BombBooster.spec.ts
+++ b/__tests__/core/BombBooster.spec.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -16,7 +16,7 @@ const cfg: BoardConfig = {
 };
 
 describe("BombBooster", () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BombBooster.spec.ts
+++ b/__tests__/core/BombBooster.spec.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -16,7 +16,7 @@ const cfg: BoardConfig = {
 };
 
 describe("BombBooster", () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BombBooster.spec.ts
+++ b/__tests__/core/BombBooster.spec.ts
@@ -4,6 +4,7 @@ import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { BombBooster } from "../../assets/scripts/core/boosters/BombBooster";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 const cfg: BoardConfig = {
   cols: 3,
@@ -30,15 +31,17 @@ describe("BombBooster", () => {
     const board = new Board(cfg, tiles);
     const booster = new BombBooster(board, bus, 1, 1);
     const events: string[] = [];
-    bus.on("MoveCompleted", () => events.push("MoveCompleted"));
+    bus.on(EventNames.MoveCompleted, () =>
+      events.push(EventNames.MoveCompleted),
+    );
     booster.start();
 
-    bus.emit("GroupSelected", new cc.Vec2(1, 1));
+    bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 1));
     await new Promise((r) => setImmediate(r));
 
     expect(booster.charges).toBe(0);
-    expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "bomb");
-    expect(events).toEqual(["MoveCompleted"]);
+    expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterConsumed, "bomb");
+    expect(events).toEqual([EventNames.MoveCompleted]);
     // neighbors cleared
     for (let x = 0; x < 3; x++) {
       for (let y = 0; y < 3; y++) {

--- a/__tests__/core/BombCommand.spec.ts
+++ b/__tests__/core/BombCommand.spec.ts
@@ -4,6 +4,7 @@ import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { BombCommand } from "../../assets/scripts/core/board/commands/BombCommand";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 const cfg: BoardConfig = {
   cols: 3,
@@ -30,12 +31,12 @@ describe("BombCommand", () => {
     const board = new Board(cfg, tiles);
     const cmd = new BombCommand(board, new cc.Vec2(1, 1), 1, bus);
     const seq: string[] = [];
-    bus.on("removeDone", () => seq.push("removeDone"));
-    bus.on("MoveCompleted", () => seq.push("MoveCompleted"));
+    bus.on(EventNames.TilesRemoved, () => seq.push(EventNames.TilesRemoved));
+    bus.on(EventNames.MoveCompleted, () => seq.push(EventNames.MoveCompleted));
 
     await cmd.execute();
 
-    expect(seq).toEqual(["removeDone", "MoveCompleted"]);
+    expect(seq).toEqual([EventNames.TilesRemoved, EventNames.MoveCompleted]);
     // center tile remains, остальные восемь должны быть пустыми
     for (let x = 0; x < 3; x++) {
       for (let y = 0; y < 3; y++) {

--- a/__tests__/core/BombCommand.spec.ts
+++ b/__tests__/core/BombCommand.spec.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -16,7 +16,7 @@ const cfg: BoardConfig = {
 };
 
 describe("BombCommand", () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BombCommand.spec.ts
+++ b/__tests__/core/BombCommand.spec.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -16,7 +16,7 @@ const cfg: BoardConfig = {
 };
 
 describe("BombCommand", () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BoosterService.spec.ts
+++ b/__tests__/core/BoosterService.spec.ts
@@ -1,10 +1,10 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 import { BoosterService } from "../../assets/scripts/core/boosters/BoosterService";
 import type { Booster } from "../../assets/scripts/core/boosters/Booster";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("BoosterService", () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BoosterService.spec.ts
+++ b/__tests__/core/BoosterService.spec.ts
@@ -1,10 +1,10 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 import { BoosterService } from "../../assets/scripts/core/boosters/BoosterService";
 import type { Booster } from "../../assets/scripts/core/boosters/Booster";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("BoosterService", () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/BoosterService.spec.ts
+++ b/__tests__/core/BoosterService.spec.ts
@@ -1,6 +1,7 @@
 import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
 import { BoosterService } from "../../assets/scripts/core/boosters/BoosterService";
 import type { Booster } from "../../assets/scripts/core/boosters/Booster";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("BoosterService", () => {
   const bus = new ExtendedEventTarget();
@@ -45,7 +46,7 @@ describe("BoosterService", () => {
     svc.register(b.booster);
     svc.activate("bomb");
     expect(b.started).toBe(true);
-    expect(emitSpy).toHaveBeenCalledWith("BoosterActivated", "bomb");
+    expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterActivated, "bomb");
   });
 
   it("activate does nothing when canActivate false", () => {
@@ -63,12 +64,12 @@ describe("BoosterService", () => {
     svc.register(booster);
     svc.consume("bomb");
     expect(booster.charges).toBe(1);
-    expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "bomb");
+    expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterConsumed, "bomb");
   });
 
   it("cancel emits BoosterCancelled", () => {
     const svc = new BoosterService(bus);
     svc.cancel();
-    expect(emitSpy).toHaveBeenCalledWith("BoosterCancelled");
+    expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterCancelled);
   });
 });

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -1,6 +1,6 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
-const bus = new EventBus();
+const bus = new InfrastructureEventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import {

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -14,6 +14,7 @@ import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 import { ScoreStrategyQuadratic } from "../../assets/scripts/core/rules/ScoreStrategyQuadratic";
 import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 const cfg: BoardConfig = {
   cols: 2,
@@ -47,7 +48,7 @@ beforeEach(() => {
 it("start emits WaitingInput", () => {
   const fsm = createFSM();
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
   expect(states).toEqual(["WaitingInput"]);
 });
@@ -56,9 +57,9 @@ it("start emits WaitingInput", () => {
 it("group selection performs move and returns to WaitingInput", async () => {
   const fsm = createFSM();
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("GroupSelected", new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states.slice(0, 5)).toEqual([
     "WaitingInput",
@@ -73,9 +74,9 @@ it("group selection performs move and returns to WaitingInput", async () => {
 it("wins when target score reached", async () => {
   const fsm = createFSM(5);
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("GroupSelected", new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states).toContain("Win");
 });
@@ -84,22 +85,22 @@ it("wins when target score reached", async () => {
 it("handles booster activate and cancel", () => {
   const fsm = createFSM();
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
   // activation now passes booster id
-  bus.emit("BoosterActivated", "bomb");
-  bus.emit("BoosterConsumed");
+  bus.emit(EventNames.BoosterActivated, "bomb");
+  bus.emit(EventNames.BoosterConsumed);
   expect(states).toEqual(["WaitingInput", "BoosterInput", "ExecutingMove"]);
 });
 
 it("cancels booster back to WaitingInput", () => {
   const fsm = createFSM();
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
   // include id to match BoosterService API
-  bus.emit("BoosterActivated", "bomb");
-  bus.emit("BoosterCancelled");
+  bus.emit(EventNames.BoosterActivated, "bomb");
+  bus.emit(EventNames.BoosterCancelled);
   expect(states).toEqual(["WaitingInput", "BoosterInput", "WaitingInput"]);
 });
 
@@ -123,9 +124,9 @@ it("moves to Lose when turns end", async () => {
     0,
   );
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("GroupSelected", new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   expect(states).toContain("Lose");
 });
@@ -137,9 +138,9 @@ it("shuffles board when no moves left", async () => {
   ]);
   const fsm = createFSM(100, board);
   const states: GameState[] = [];
-  bus.on("StateChanged", (s) => states.push(s as GameState));
+  bus.on(EventNames.StateChanged, (s) => states.push(s as GameState));
   fsm.start();
-  bus.emit("GroupSelected", new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
   await new Promise((r) => setImmediate(r));
   const lastTwo = states.slice(-2);
   expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);

--- a/__tests__/core/GameStateMachine.spec.ts
+++ b/__tests__/core/GameStateMachine.spec.ts
@@ -1,6 +1,6 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
-const bus = new ExtendedEventTarget();
+const bus = new EventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import {

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -1,6 +1,6 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
-const bus = new EventBus();
+const bus = new InfrastructureEventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import { Board } from "../../assets/scripts/core/board/Board";

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -7,6 +7,7 @@ import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory, TileKind } from "../../assets/scripts/core/board/Tile";
 import { MoveExecutor } from "../../assets/scripts/core/board/MoveExecutor";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 const cfg: BoardConfig = {
   cols: 2,
@@ -30,18 +31,20 @@ it("executes remove, fall and fill then emits MoveCompleted", async () => {
   ]);
   const executor = new MoveExecutor(board, bus);
   const sequence: string[] = [];
-  bus.on("removeDone", () => sequence.push("removeDone"));
-  bus.on("fallDone", () => sequence.push("fallDone"));
-  bus.on("fillDone", () => sequence.push("fillDone"));
-  bus.on("MoveCompleted", () => sequence.push("MoveCompleted"));
+  bus.on(EventNames.TilesRemoved, () => sequence.push(EventNames.TilesRemoved));
+  bus.on(EventNames.FallDone, () => sequence.push(EventNames.FallDone));
+  bus.on(EventNames.FillDone, () => sequence.push(EventNames.FillDone));
+  bus.on(EventNames.MoveCompleted, () =>
+    sequence.push(EventNames.MoveCompleted),
+  );
 
   await executor.execute([new cc.Vec2(0, 0), new cc.Vec2(1, 0)]);
 
   expect(sequence).toEqual([
-    "removeDone",
-    "fallDone",
-    "fillDone",
-    "MoveCompleted",
+    EventNames.TilesRemoved,
+    EventNames.FallDone,
+    EventNames.FillDone,
+    EventNames.MoveCompleted,
   ]);
 });
 
@@ -53,7 +56,7 @@ it("ignores out of bounds tiles in group", async () => {
   ]);
   const executor = new MoveExecutor(board, bus);
   await executor.execute([new cc.Vec2(0, 0), new cc.Vec2(5, 5)]);
-  expect(emitSpy).toHaveBeenLastCalledWith("MoveCompleted");
+  expect(emitSpy).toHaveBeenLastCalledWith(EventNames.MoveCompleted);
 });
 
 // error case: empty group should reject

--- a/__tests__/core/MoveExecutor.spec.ts
+++ b/__tests__/core/MoveExecutor.spec.ts
@@ -1,6 +1,6 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
-const bus = new ExtendedEventTarget();
+const bus = new EventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import { Board } from "../../assets/scripts/core/board/Board";

--- a/__tests__/core/ShuffleService.spec.ts
+++ b/__tests__/core/ShuffleService.spec.ts
@@ -1,6 +1,6 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
-const bus = new EventBus();
+const bus = new InfrastructureEventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import { Board } from "../../assets/scripts/core/board/Board";

--- a/__tests__/core/ShuffleService.spec.ts
+++ b/__tests__/core/ShuffleService.spec.ts
@@ -8,6 +8,7 @@ import { BoardSolver } from "../../assets/scripts/core/board/BoardSolver";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { ShuffleService } from "../../assets/scripts/core/board/ShuffleService";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 const cfgSingle: BoardConfig = {
   cols: 1,
@@ -51,11 +52,11 @@ it("auto shuffles until limit then emits ShuffleLimitExceeded", () => {
   service.ensureMoves();
   service.ensureMoves();
   expect(emitSpy.mock.calls.map((c) => c[0])).toEqual([
-    "AutoShuffle",
-    "ShuffleDone",
-    "AutoShuffle",
-    "ShuffleDone",
-    "ShuffleLimitExceeded",
+    EventNames.AutoShuffle,
+    EventNames.ShuffleDone,
+    EventNames.AutoShuffle,
+    EventNames.ShuffleDone,
+    EventNames.ShuffleLimitExceeded,
   ]);
 });
 
@@ -69,7 +70,7 @@ it("reset allows shuffling again", () => {
   emitSpy.mockClear();
   service.reset();
   service.ensureMoves();
-  expect(emitSpy.mock.calls[0][0]).toBe("AutoShuffle");
+  expect(emitSpy.mock.calls[0][0]).toBe(EventNames.AutoShuffle);
 });
 
 // direct shuffle mixes tiles and emits ShuffleDone
@@ -80,5 +81,5 @@ it("shuffle performs Fisher-Yates step", () => {
   const solver = new BoardSolver(board);
   const service = new ShuffleService(board, solver, bus, 1);
   service.shuffle();
-  expect(emitSpy).toHaveBeenCalledWith("ShuffleDone");
+  expect(emitSpy).toHaveBeenCalledWith(EventNames.ShuffleDone);
 });

--- a/__tests__/core/ShuffleService.spec.ts
+++ b/__tests__/core/ShuffleService.spec.ts
@@ -1,6 +1,6 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
-const bus = new ExtendedEventTarget();
+const bus = new EventBus();
 const emitSpy = jest.spyOn(bus, "emit");
 
 import { Board } from "../../assets/scripts/core/board/Board";

--- a/__tests__/core/SwapCommand.spec.ts
+++ b/__tests__/core/SwapCommand.spec.ts
@@ -4,6 +4,7 @@ import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { SwapCommand } from "../../assets/scripts/core/board/commands/SwapCommand";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("SwapCommand", () => {
   const bus = new ExtendedEventTarget();
@@ -34,12 +35,12 @@ describe("SwapCommand", () => {
       bus,
     );
     const seq: string[] = [];
-    bus.on("SwapDone", () => seq.push("SwapDone"));
+    bus.on(EventNames.SwapDone, () => seq.push(EventNames.SwapDone));
 
     await cmd.execute();
 
     expect(board.tileAt(new cc.Vec2(0, 0))?.color).toBe("blue");
     expect(board.tileAt(new cc.Vec2(1, 0))?.color).toBe("red");
-    expect(seq).toEqual(["SwapDone"]);
+    expect(seq).toEqual([EventNames.SwapDone]);
   });
 });

--- a/__tests__/core/SwapCommand.spec.ts
+++ b/__tests__/core/SwapCommand.spec.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -7,7 +7,7 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("SwapCommand", () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/SwapCommand.spec.ts
+++ b/__tests__/core/SwapCommand.spec.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -7,7 +7,7 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("SwapCommand", () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/TeleportBooster.spec.ts
+++ b/__tests__/core/TeleportBooster.spec.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -7,7 +7,7 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("TeleportBooster", () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/TeleportBooster.spec.ts
+++ b/__tests__/core/TeleportBooster.spec.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 
 import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
@@ -7,7 +7,7 @@ import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("TeleportBooster", () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
 
   beforeEach(() => {

--- a/__tests__/core/TeleportBooster.spec.ts
+++ b/__tests__/core/TeleportBooster.spec.ts
@@ -4,6 +4,7 @@ import { Board } from "../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../assets/scripts/core/board/Tile";
 import { TeleportBooster } from "../../assets/scripts/core/boosters/TeleportBooster";
 import { BoardConfig } from "../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 describe("TeleportBooster", () => {
   const bus = new ExtendedEventTarget();
@@ -30,16 +31,18 @@ describe("TeleportBooster", () => {
     ]);
     const booster = new TeleportBooster(board, bus, 1);
     const seq: string[] = [];
-    bus.on("SwapDone", () => seq.push("SwapDone"));
-    bus.on("BoosterConsumed", () => seq.push("BoosterConsumed"));
+    bus.on(EventNames.SwapDone, () => seq.push(EventNames.SwapDone));
+    bus.on(EventNames.BoosterConsumed, () =>
+      seq.push(EventNames.BoosterConsumed),
+    );
 
     booster.start();
-    bus.emit("GroupSelected", new cc.Vec2(1, 0));
-    bus.emit("GroupSelected", new cc.Vec2(1, 1));
+    bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
+    bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 1));
     await new Promise((r) => setImmediate(r));
 
     expect(booster.charges).toBe(0);
-    expect(seq).toEqual(["SwapDone", "BoosterConsumed"]);
+    expect(seq).toEqual([EventNames.SwapDone, EventNames.BoosterConsumed]);
     expect(board.colorAt(new cc.Vec2(1, 0))).toBe("red");
     expect(board.colorAt(new cc.Vec2(1, 1))).toBe("blue");
   });
@@ -58,15 +61,17 @@ describe("TeleportBooster", () => {
     ]);
     const booster = new TeleportBooster(board, bus, 1);
     const events: string[] = [];
-    bus.on("SwapCancelled", () => events.push("SwapCancelled"));
+    bus.on(EventNames.SwapCancelled, () =>
+      events.push(EventNames.SwapCancelled),
+    );
 
     booster.start();
-    bus.emit("GroupSelected", new cc.Vec2(0, 0));
-    bus.emit("GroupSelected", new cc.Vec2(1, 0));
+    bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
+    bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
     await new Promise((r) => setImmediate(r));
 
     expect(booster.charges).toBe(1);
-    expect(events).toEqual(["SwapCancelled"]);
+    expect(events).toEqual([EventNames.SwapCancelled]);
     expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
     expect(board.colorAt(new cc.Vec2(1, 0))).toBe("blue");
   });

--- a/__tests__/core/TurnManager.spec.ts
+++ b/__tests__/core/TurnManager.spec.ts
@@ -1,11 +1,11 @@
-import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
 import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
-let bus: ExtendedEventTarget;
+let bus: EventBus;
 let emitSpy: jest.SpyInstance;
 beforeAll(() => {
-  bus = new ExtendedEventTarget();
+  bus = new EventBus();
   emitSpy = jest.spyOn(bus, "emit");
 });
 

--- a/__tests__/core/TurnManager.spec.ts
+++ b/__tests__/core/TurnManager.spec.ts
@@ -1,11 +1,11 @@
-import { EventBus } from "../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../assets/scripts/infrastructure/InfrastructureEventBus";
 import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
 import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
-let bus: EventBus;
+let bus: InfrastructureEventBus;
 let emitSpy: jest.SpyInstance;
 beforeAll(() => {
-  bus = new EventBus();
+  bus = new InfrastructureEventBus();
   emitSpy = jest.spyOn(bus, "emit");
 });
 

--- a/__tests__/core/TurnManager.spec.ts
+++ b/__tests__/core/TurnManager.spec.ts
@@ -1,5 +1,6 @@
 import { ExtendedEventTarget } from "../../assets/scripts/infrastructure/ExtendedEventTarget";
 import { TurnManager } from "../../assets/scripts/core/rules/TurnManager";
+import { EventNames } from "../../assets/scripts/core/events/EventNames";
 
 let bus: ExtendedEventTarget;
 let emitSpy: jest.SpyInstance;
@@ -26,7 +27,7 @@ it("useTurn decreases remaining turns", () => {
 it("emits OutOfTurns when reaching zero", () => {
   const tm = new TurnManager(1, bus);
   let called = 0;
-  bus.on("OutOfTurns", () => called++);
+  bus.on(EventNames.OutOfTurns, () => called++);
   tm.useTurn();
   expect(called).toBe(1);
 });

--- a/__tests__/core/boosters/BombBooster.spec.ts
+++ b/__tests__/core/boosters/BombBooster.spec.ts
@@ -13,7 +13,7 @@ jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
   };
 });
 
-import { ExtendedEventTarget } from "../../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
 import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { BombBooster } from "../../../assets/scripts/core/boosters/BombBooster";
@@ -31,7 +31,7 @@ const cfg: BoardConfig = {
 
 // Проверяем расход заряда и радиус действия бомбы
 it("consumes charge and clears R-zone", async () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
   const tiles = Array.from({ length: 3 }, () =>
     Array.from({ length: 3 }, () => TileFactory.createNormal("red")),

--- a/__tests__/core/boosters/BombBooster.spec.ts
+++ b/__tests__/core/boosters/BombBooster.spec.ts
@@ -18,6 +18,7 @@ import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { BombBooster } from "../../../assets/scripts/core/boosters/BombBooster";
 import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../../assets/scripts/core/events/EventNames";
 
 const cfg: BoardConfig = {
   cols: 3,
@@ -39,11 +40,11 @@ it("consumes charge and clears R-zone", async () => {
   const booster = new BombBooster(board, bus, 1, 1);
 
   booster.start();
-  bus.emit("GroupSelected", new cc.Vec2(1, 1));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 1));
   await new Promise((r) => setImmediate(r));
 
   expect(booster.charges).toBe(0);
-  expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "bomb");
+  expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterConsumed, "bomb");
   for (let x = 0; x < 3; x++) {
     for (let y = 0; y < 3; y++) {
       const p = new cc.Vec2(x, y);

--- a/__tests__/core/boosters/BombBooster.spec.ts
+++ b/__tests__/core/boosters/BombBooster.spec.ts
@@ -13,7 +13,7 @@ jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
   };
 });
 
-import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../assets/scripts/infrastructure/InfrastructureEventBus";
 import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { BombBooster } from "../../../assets/scripts/core/boosters/BombBooster";
@@ -31,7 +31,7 @@ const cfg: BoardConfig = {
 
 // Проверяем расход заряда и радиус действия бомбы
 it("consumes charge and clears R-zone", async () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
   const tiles = Array.from({ length: 3 }, () =>
     Array.from({ length: 3 }, () => TileFactory.createNormal("red")),

--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -18,6 +18,7 @@ import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { TeleportBooster } from "../../../assets/scripts/core/boosters/TeleportBooster";
 import { BoardConfig } from "../../../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../../../assets/scripts/core/events/EventNames";
 
 const cfg2x2: BoardConfig = {
   cols: 2,
@@ -38,17 +39,19 @@ it("consumes charge on successful swap", async () => {
   ]);
   const booster = new TeleportBooster(board, bus, 1);
   const seq: string[] = [];
-  bus.on("SwapDone", () => seq.push("SwapDone"));
-  bus.on("BoosterConsumed", () => seq.push("BoosterConsumed"));
+  bus.on(EventNames.SwapDone, () => seq.push(EventNames.SwapDone));
+  bus.on(EventNames.BoosterConsumed, () =>
+    seq.push(EventNames.BoosterConsumed),
+  );
 
   booster.start();
-  bus.emit("GroupSelected", new cc.Vec2(1, 0));
-  bus.emit("GroupSelected", new cc.Vec2(1, 1));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 1));
   await new Promise((r) => setImmediate(r));
 
   expect(booster.charges).toBe(0);
-  expect(seq).toEqual(["SwapDone", "BoosterConsumed"]);
-  expect(emitSpy).toHaveBeenCalledWith("BoosterConsumed", "teleport");
+  expect(seq).toEqual([EventNames.SwapDone, EventNames.BoosterConsumed]);
+  expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterConsumed, "teleport");
   expect(board.colorAt(new cc.Vec2(1, 0))).toBe("red");
   expect(board.colorAt(new cc.Vec2(1, 1))).toBe("blue");
 });
@@ -70,15 +73,15 @@ it("cancels swap when no moves available", async () => {
   );
   const booster = new TeleportBooster(board, bus, 1);
   const events: string[] = [];
-  bus.on("SwapCancelled", () => events.push("SwapCancelled"));
+  bus.on(EventNames.SwapCancelled, () => events.push(EventNames.SwapCancelled));
 
   booster.start();
-  bus.emit("GroupSelected", new cc.Vec2(0, 0));
-  bus.emit("GroupSelected", new cc.Vec2(1, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
   await new Promise((r) => setImmediate(r));
 
   expect(booster.charges).toBe(1);
-  expect(events).toEqual(["SwapCancelled"]);
+  expect(events).toEqual([EventNames.SwapCancelled]);
   expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
   expect(board.colorAt(new cc.Vec2(1, 0))).toBe("blue");
 });

--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -13,7 +13,7 @@ jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
   };
 });
 
-import { ExtendedEventTarget } from "../../../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
 import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { TeleportBooster } from "../../../assets/scripts/core/boosters/TeleportBooster";
@@ -31,7 +31,7 @@ const cfg2x2: BoardConfig = {
 
 // Swap происходит и заряд тратится, если после обмена есть ходы
 it("consumes charge on successful swap", async () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const emitSpy = jest.spyOn(bus, "emit");
   const board = new Board(cfg2x2, [
     [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
@@ -59,7 +59,7 @@ it("consumes charge on successful swap", async () => {
 // Когда после обмена нет ходов, заряд не тратится, а событие SwapCancelled
 // уведомляет о возврате
 it("cancels swap when no moves available", async () => {
-  const bus = new ExtendedEventTarget();
+  const bus = new EventBus();
   const board = new Board(
     {
       cols: 2,

--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -13,7 +13,7 @@ jest.mock("../../../assets/scripts/infrastructure/EventBus", () => {
   };
 });
 
-import { EventBus } from "../../../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../assets/scripts/infrastructure/InfrastructureEventBus";
 import { Board } from "../../../assets/scripts/core/board/Board";
 import { TileFactory } from "../../../assets/scripts/core/board/Tile";
 import { TeleportBooster } from "../../../assets/scripts/core/boosters/TeleportBooster";
@@ -31,7 +31,7 @@ const cfg2x2: BoardConfig = {
 
 // Swap происходит и заряд тратится, если после обмена есть ходы
 it("consumes charge on successful swap", async () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
   const board = new Board(cfg2x2, [
     [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
@@ -59,7 +59,7 @@ it("consumes charge on successful swap", async () => {
 // Когда после обмена нет ходов, заряд не тратится, а событие SwapCancelled
 // уведомляет о возврате
 it("cancels swap when no moves available", async () => {
-  const bus = new EventBus();
+  const bus = new InfrastructureEventBus();
   const board = new Board(
     {
       cols: 2,

--- a/assets/scenes/GameScene.fire
+++ b/assets/scenes/GameScene.fire
@@ -82,6 +82,9 @@
       },
       {
         "__id__": 45
+      },
+      {
+        "__id__": 46
       }
     ],
     "_prefab": null,
@@ -1700,5 +1703,15 @@
     "_originalWidth": 1080,
     "_originalHeight": 1920,
     "_id": "29zXboiXFBKoIV4PQ2liTe"
+  },
+  {
+    "__type__": "98446nm3NlM75zj6A1JWo0f",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "_id": "3clvPFaPJCkr8P1TfYX8qN"
   }
 ]

--- a/assets/scripts/GameScene.ts
+++ b/assets/scripts/GameScene.ts
@@ -1,0 +1,40 @@
+import { EventBus } from "./core/EventBus";
+import { GameStateMachine } from "./core/game/GameStateMachine";
+import { BoardSolver } from "./core/board/BoardSolver";
+import { MoveExecutor } from "./core/board/MoveExecutor";
+import { ScoreStrategyQuadratic } from "./core/rules/ScoreStrategyQuadratic";
+import { TurnManager } from "./core/rules/TurnManager";
+import GameBoardController from "./ui/controllers/GameBoardController";
+
+const { ccclass } = cc._decorator;
+
+@ccclass()
+export default class GameScene extends cc.Component {
+  private fsm: GameStateMachine | null = null;
+
+  start(): void {
+    const boardCtrl = this.getComponentInChildren(GameBoardController);
+    if (!boardCtrl) {
+      console.error("GameBoardController not found");
+      return;
+    }
+
+    const board = boardCtrl.getBoard();
+    const solver = new BoardSolver(board);
+    const executor = new MoveExecutor(board, EventBus);
+    const scoreStrategy = new ScoreStrategyQuadratic(1);
+    const turns = new TurnManager(20, EventBus);
+
+    this.fsm = new GameStateMachine(
+      EventBus,
+      board,
+      solver,
+      executor,
+      scoreStrategy,
+      turns,
+      100,
+      3,
+    );
+    this.fsm.start();
+  }
+}

--- a/assets/scripts/GameScene.ts.meta
+++ b/assets/scripts/GameScene.ts.meta
@@ -1,0 +1,10 @@
+{
+  "ver": "1.1.0",
+  "uuid": "984469e6-dcd9-4cef-9ce3-e80d495a8d1f",
+  "importer": "typescript",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}

--- a/assets/scripts/core/EventBus.ts
+++ b/assets/scripts/core/EventBus.ts
@@ -1,9 +1,9 @@
-// Глобальная шина событий теперь основана на cc.EventTarget
-import { ExtendedEventTarget } from "../infrastructure/ExtendedEventTarget";
+// Глобальная шина событий теперь основана на cc.EventTarget with diagnostics
+import { EventBus as InfrastructureEventBus } from "../infrastructure/EventBus";
 
 /**
  * Глобальный экземпляр EventBus используется во всех частях игры.
  * Мы отказались от сторонней библиотеки eventemitter2
- * в пользу упрощённой обёртки на cc.EventTarget.
+ * в пользу обёртки на cc.EventTarget с отслеживанием подписчиков.
  */
-export const EventBus = new ExtendedEventTarget();
+export const EventBus = new InfrastructureEventBus();

--- a/assets/scripts/core/EventBus.ts
+++ b/assets/scripts/core/EventBus.ts
@@ -1,5 +1,5 @@
 // Глобальная шина событий теперь основана на cc.EventTarget with diagnostics
-import { EventBus as InfrastructureEventBus } from "../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../infrastructure/InfrastructureEventBus";
 
 /**
  * Глобальный экземпляр EventBus используется во всех частях игры.

--- a/assets/scripts/core/board/BoardSolver.ts
+++ b/assets/scripts/core/board/BoardSolver.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../EventBus";
+import { EventNames } from "../events/EventNames";
 import { Board } from "./Board";
 import { Tile, TileKind } from "./Tile";
 import { BoardConfig } from "../../config/ConfigLoader";
@@ -136,7 +137,7 @@ export class BoardSolver {
     });
 
     // Notify listeners that a group has been found
-    EventBus.emit("GroupFound", result);
+    EventBus.emit(EventNames.GroupFound, result);
     return result;
   }
 

--- a/assets/scripts/core/board/MoveExecutor.ts
+++ b/assets/scripts/core/board/MoveExecutor.ts
@@ -1,5 +1,5 @@
 import { Board } from "./Board";
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { RemoveCommand } from "./commands/RemoveCommand";
 import { FallCommand } from "./commands/FallCommand";
 import { FillCommand } from "./commands/FillCommand";
@@ -16,7 +16,7 @@ import { EventNames } from "../events/EventNames";
 export class MoveExecutor {
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
   ) {}
 
   async execute(group: cc.Vec2[]): Promise<void> {

--- a/assets/scripts/core/board/MoveExecutor.ts
+++ b/assets/scripts/core/board/MoveExecutor.ts
@@ -6,6 +6,7 @@ import { FillCommand } from "./commands/FillCommand";
 import { TileFactory } from "./Tile";
 import { BoardConfig } from "../../config/ConfigLoader";
 import { SuperTileFactory } from "../boosters/SuperTileFactory";
+import { EventNames } from "../events/EventNames";
 
 /**
  * Executes a full player move by removing a group, letting tiles fall
@@ -28,7 +29,7 @@ export class MoveExecutor {
     const startTile = this.board.tileAt(start);
 
     // 1. Remove tiles and wait for completion
-    const removeDone = this.wait("removeDone");
+    const removeDone = this.wait(EventNames.TilesRemoved);
     new RemoveCommand(this.board, this.bus, group).execute();
     const [dirtyCols] = (await removeDone) as [number[]];
 
@@ -42,17 +43,17 @@ export class MoveExecutor {
     }
 
     // 2. Let tiles fall in affected columns
-    const fallDone = this.wait("fallDone");
+    const fallDone = this.wait(EventNames.FallDone);
     new FallCommand(this.board, this.bus, dirtyCols).execute();
     const [emptySlots] = (await fallDone) as [cc.Vec2[]];
 
     // 3. Fill empty spaces with new tiles
-    const fillDone = this.wait("fillDone");
+    const fillDone = this.wait(EventNames.FillDone);
     new FillCommand(this.board, this.bus, emptySlots).execute();
     await fillDone;
 
     // Signal completion of the whole move
-    this.bus.emit("MoveCompleted");
+    this.bus.emit(EventNames.MoveCompleted);
   }
 
   /**

--- a/assets/scripts/core/board/MoveExecutor.ts
+++ b/assets/scripts/core/board/MoveExecutor.ts
@@ -1,5 +1,5 @@
 import { Board } from "./Board";
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { RemoveCommand } from "./commands/RemoveCommand";
 import { FallCommand } from "./commands/FallCommand";
 import { FillCommand } from "./commands/FillCommand";
@@ -16,7 +16,7 @@ import { EventNames } from "../events/EventNames";
 export class MoveExecutor {
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
   ) {}
 
   async execute(group: cc.Vec2[]): Promise<void> {

--- a/assets/scripts/core/board/ShuffleService.ts
+++ b/assets/scripts/core/board/ShuffleService.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { Board } from "./Board";
 import { BoardSolver } from "./BoardSolver";
 import { Tile } from "./Tile";
@@ -10,7 +10,7 @@ export class ShuffleService {
   constructor(
     private board: Board,
     private solver: BoardSolver,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     private maxShuffles: number = 3,
   ) {}
 

--- a/assets/scripts/core/board/ShuffleService.ts
+++ b/assets/scripts/core/board/ShuffleService.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { Board } from "./Board";
 import { BoardSolver } from "./BoardSolver";
 import { Tile } from "./Tile";
@@ -10,7 +10,7 @@ export class ShuffleService {
   constructor(
     private board: Board,
     private solver: BoardSolver,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     private maxShuffles: number = 3,
   ) {}
 

--- a/assets/scripts/core/board/ShuffleService.ts
+++ b/assets/scripts/core/board/ShuffleService.ts
@@ -3,6 +3,7 @@ import { Board } from "./Board";
 import { BoardSolver } from "./BoardSolver";
 import { Tile } from "./Tile";
 import { BoardConfig } from "../../config/ConfigLoader";
+import { EventNames } from "../events/EventNames";
 
 export class ShuffleService {
   private shuffleCount = 0;
@@ -27,14 +28,14 @@ export class ShuffleService {
 
     if (this.shuffleCount < this.maxShuffles) {
       // Сообщаем, что будет автоматическая перетасовка.
-      this.bus.emit("AutoShuffle");
+      this.bus.emit(EventNames.AutoShuffle);
       // Увеличиваем счётчик перед самой операцией.
       this.shuffleCount++;
       // Перемешиваем тайлы на поле.
       this.shuffle();
     } else {
       // Достигнут предел, больше тасовать нельзя.
-      this.bus.emit("ShuffleLimitExceeded");
+      this.bus.emit(EventNames.ShuffleLimitExceeded);
     }
   }
 
@@ -68,7 +69,7 @@ export class ShuffleService {
     }
 
     // Уведомляем слушателей об окончании перетасовки.
-    this.bus.emit("ShuffleDone");
+    this.bus.emit(EventNames.ShuffleDone);
   }
 
   /**

--- a/assets/scripts/core/board/commands/BombCommand.ts
+++ b/assets/scripts/core/board/commands/BombCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../infrastructure/EventBus";
 import { ICommand } from "./ICommand";
 import { RemoveCommand } from "./RemoveCommand";
 import { EventNames } from "../../events/EventNames";
@@ -12,7 +12,7 @@ export class BombCommand implements ICommand {
     private board: Board,
     private center: cc.Vec2,
     private radius: number,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
   ) {}
 
   async execute(): Promise<void> {

--- a/assets/scripts/core/board/commands/BombCommand.ts
+++ b/assets/scripts/core/board/commands/BombCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { RemoveCommand } from "./RemoveCommand";
 import { EventNames } from "../../events/EventNames";
@@ -12,7 +12,7 @@ export class BombCommand implements ICommand {
     private board: Board,
     private center: cc.Vec2,
     private radius: number,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
   ) {}
 
   async execute(): Promise<void> {

--- a/assets/scripts/core/board/commands/BombCommand.ts
+++ b/assets/scripts/core/board/commands/BombCommand.ts
@@ -2,6 +2,7 @@ import { Board } from "../Board";
 import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
 import { ICommand } from "./ICommand";
 import { RemoveCommand } from "./RemoveCommand";
+import { EventNames } from "../../events/EventNames";
 
 /**
  * Схлопывает все тайлы в радиусе R от center.
@@ -34,11 +35,11 @@ export class BombCommand implements ICommand {
 
     // Ждём завершения RemoveCommand
     await new Promise<void>((resolve) => {
-      this.bus.once("removeDone", () => resolve());
+      this.bus.once(EventNames.TilesRemoved, () => resolve());
       void new RemoveCommand(this.board, this.bus, group).execute();
     });
 
     // Отправляем событие о завершении применения бустера
-    this.bus.emit("MoveCompleted");
+    this.bus.emit(EventNames.MoveCompleted);
   }
 }

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/InfrastructureEventBus";
+import { InfrastructureEventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { Tile } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
@@ -14,7 +14,7 @@ import { EventNames } from "../../events/EventNames";
 export class FallCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     private columns: number[],
   ) {}
 

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -3,10 +3,11 @@ import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget
 import { ICommand } from "./ICommand";
 import { Tile } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
+import { EventNames } from "../../events/EventNames";
 
 /**
  * Shifts tiles down in specified columns to remove gaps.
- * Emits 'fallStart' and 'fallDone'. The 'fallDone' event carries
+ * Emits 'FallStarted' and 'FallDone'. The 'FallDone' event carries
  * the list of coordinates that became empty at the top of columns
  * after falling which should be filled by the next command.
  */
@@ -27,7 +28,7 @@ export class FallCommand implements ICommand {
       throw new Error("FallCommand: no columns specified");
     }
 
-    this.bus.emit("fallStart", this.columns);
+    this.bus.emit(EventNames.FallStarted, this.columns);
 
     const emptySlots: cc.Vec2[] = [];
     const rows = this.cfg.rows;
@@ -55,6 +56,6 @@ export class FallCommand implements ICommand {
       }
     }
 
-    this.bus.emit("fallDone", emptySlots);
+    this.bus.emit(EventNames.FallDone, emptySlots);
   }
 }

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/EventBus";
+import { EventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { Tile } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";

--- a/assets/scripts/core/board/commands/FallCommand.ts
+++ b/assets/scripts/core/board/commands/FallCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../infrastructure/EventBus";
 import { ICommand } from "./ICommand";
 import { Tile } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
@@ -14,7 +14,7 @@ import { EventNames } from "../../events/EventNames";
 export class FallCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     private columns: number[],
   ) {}
 

--- a/assets/scripts/core/board/commands/FillCommand.ts
+++ b/assets/scripts/core/board/commands/FillCommand.ts
@@ -3,10 +3,11 @@ import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget
 import { ICommand } from "./ICommand";
 import { TileFactory, TileColor } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
+import { EventNames } from "../../events/EventNames";
 
 /**
  * Generates new tiles in provided empty slots.
- * Emits 'fillStart' and 'fillDone'. No payload is passed with 'fillDone'.
+ * Emits 'FillStarted' and 'FillDone'. No payload is passed with 'FillDone'.
  */
 export class FillCommand implements ICommand {
   constructor(
@@ -25,7 +26,7 @@ export class FillCommand implements ICommand {
       throw new Error("FillCommand: no slots provided");
     }
 
-    this.bus.emit("fillStart", this.slots);
+    this.bus.emit(EventNames.FillStarted, this.slots);
 
     for (const p of this.slots) {
       if (!this.board.inBounds(p)) continue;
@@ -33,7 +34,7 @@ export class FillCommand implements ICommand {
       this.board.setTile(p, TileFactory.createNormal(color));
     }
 
-    this.bus.emit("fillDone");
+    this.bus.emit(EventNames.FillDone);
   }
 
   private randomColor(): TileColor {

--- a/assets/scripts/core/board/commands/FillCommand.ts
+++ b/assets/scripts/core/board/commands/FillCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { TileFactory, TileColor } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
@@ -12,7 +12,7 @@ import { EventNames } from "../../events/EventNames";
 export class FillCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     private slots: cc.Vec2[],
   ) {}
 

--- a/assets/scripts/core/board/commands/FillCommand.ts
+++ b/assets/scripts/core/board/commands/FillCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../infrastructure/EventBus";
 import { ICommand } from "./ICommand";
 import { TileFactory, TileColor } from "../Tile";
 import { BoardConfig } from "../../../config/ConfigLoader";
@@ -12,7 +12,7 @@ import { EventNames } from "../../events/EventNames";
 export class FillCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     private slots: cc.Vec2[],
   ) {}
 

--- a/assets/scripts/core/board/commands/RemoveCommand.ts
+++ b/assets/scripts/core/board/commands/RemoveCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { EventNames } from "../../events/EventNames";
 
@@ -11,7 +11,7 @@ import { EventNames } from "../../events/EventNames";
 export class RemoveCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     private group: cc.Vec2[],
   ) {}
 

--- a/assets/scripts/core/board/commands/RemoveCommand.ts
+++ b/assets/scripts/core/board/commands/RemoveCommand.ts
@@ -1,10 +1,11 @@
 import { Board } from "../Board";
 import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
 import { ICommand } from "./ICommand";
+import { EventNames } from "../../events/EventNames";
 
 /**
  * Removes tiles belonging to the provided group from the board.
- * Emits 'removeStart' at the beginning and 'removeDone' with affected
+ * Emits 'RemoveStarted' at the beginning and 'TilesRemoved' with affected
  * column indices when finished.
  */
 export class RemoveCommand implements ICommand {
@@ -20,7 +21,7 @@ export class RemoveCommand implements ICommand {
     }
 
     // Notify listeners that removal has started
-    this.bus.emit("removeStart", this.group);
+    this.bus.emit(EventNames.RemoveStarted, this.group);
 
     const cols = new Set<number>();
     for (const p of this.group) {
@@ -33,6 +34,6 @@ export class RemoveCommand implements ICommand {
     }
 
     // Emit completion event with affected column numbers
-    this.bus.emit("removeDone", Array.from(cols));
+    this.bus.emit(EventNames.TilesRemoved, Array.from(cols));
   }
 }

--- a/assets/scripts/core/board/commands/RemoveCommand.ts
+++ b/assets/scripts/core/board/commands/RemoveCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../infrastructure/EventBus";
 import { ICommand } from "./ICommand";
 import { EventNames } from "../../events/EventNames";
 
@@ -11,7 +11,7 @@ import { EventNames } from "../../events/EventNames";
 export class RemoveCommand implements ICommand {
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     private group: cc.Vec2[],
   ) {}
 

--- a/assets/scripts/core/board/commands/SwapCommand.ts
+++ b/assets/scripts/core/board/commands/SwapCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { EventBus } from "../../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../../infrastructure/InfrastructureEventBus";
 import { ICommand } from "./ICommand";
 import { EventNames } from "../../events/EventNames";
 
@@ -11,7 +11,7 @@ export class SwapCommand implements ICommand {
     private board: Board,
     private a: cc.Vec2,
     private b: cc.Vec2,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
   ) {}
 
   async execute(): Promise<void> {

--- a/assets/scripts/core/board/commands/SwapCommand.ts
+++ b/assets/scripts/core/board/commands/SwapCommand.ts
@@ -1,5 +1,5 @@
 import { Board } from "../Board";
-import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../../infrastructure/EventBus";
 import { ICommand } from "./ICommand";
 import { EventNames } from "../../events/EventNames";
 
@@ -11,7 +11,7 @@ export class SwapCommand implements ICommand {
     private board: Board,
     private a: cc.Vec2,
     private b: cc.Vec2,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
   ) {}
 
   async execute(): Promise<void> {

--- a/assets/scripts/core/board/commands/SwapCommand.ts
+++ b/assets/scripts/core/board/commands/SwapCommand.ts
@@ -1,6 +1,7 @@
 import { Board } from "../Board";
 import { ExtendedEventTarget } from "../../../infrastructure/ExtendedEventTarget";
 import { ICommand } from "./ICommand";
+import { EventNames } from "../../events/EventNames";
 
 /**
  * Swaps tiles at two positions on the board and notifies listeners.
@@ -21,6 +22,6 @@ export class SwapCommand implements ICommand {
     const tB = this.board.tileAt(this.b);
     this.board.setTile(this.a, tB);
     this.board.setTile(this.b, tA);
-    this.bus.emit("SwapDone");
+    this.bus.emit(EventNames.SwapDone);
   }
 }

--- a/assets/scripts/core/boosters/BombBooster.ts
+++ b/assets/scripts/core/boosters/BombBooster.ts
@@ -2,6 +2,7 @@ import { Booster } from "./Booster";
 import { Board } from "../board/Board";
 import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
 import { BombCommand } from "../board/commands/BombCommand";
+import { EventNames } from "../events/EventNames";
 
 /**
  * Бомба: при активации ждёт клика,
@@ -27,12 +28,12 @@ export class BombBooster implements Booster {
     // Подписываемся на единичный выбор клетки. После клика расходуем заряд
     // и запускаем команду бомбы. Используем once, чтобы автоматически
     // снять обработчик после первого срабатывания.
-    this.bus.once("GroupSelected", (pos: unknown) => {
+    this.bus.once(EventNames.GroupSelected, (pos: unknown) => {
       if (this.charges <= 0) return;
       const p = pos as cc.Vec2;
       this.charges--;
       // уведомляем систему, что заряд израсходован
-      this.bus.emit("BoosterConsumed", this.id);
+      this.bus.emit(EventNames.BoosterConsumed, this.id);
       // выполняем команду бомбы асинхронно
       void new BombCommand(this.board, p, this.radius, this.bus).execute();
     });

--- a/assets/scripts/core/boosters/BombBooster.ts
+++ b/assets/scripts/core/boosters/BombBooster.ts
@@ -1,6 +1,6 @@
 import { Booster } from "./Booster";
 import { Board } from "../board/Board";
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { BombCommand } from "../board/commands/BombCommand";
 import { EventNames } from "../events/EventNames";
 
@@ -13,7 +13,7 @@ export class BombBooster implements Booster {
   charges: number;
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     charges: number,
     private radius: number,
   ) {

--- a/assets/scripts/core/boosters/BombBooster.ts
+++ b/assets/scripts/core/boosters/BombBooster.ts
@@ -1,6 +1,6 @@
 import { Booster } from "./Booster";
 import { Board } from "../board/Board";
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { BombCommand } from "../board/commands/BombCommand";
 import { EventNames } from "../events/EventNames";
 
@@ -13,7 +13,7 @@ export class BombBooster implements Booster {
   charges: number;
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     charges: number,
     private radius: number,
   ) {

--- a/assets/scripts/core/boosters/BoosterService.ts
+++ b/assets/scripts/core/boosters/BoosterService.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import type { Booster } from "./Booster";
 import { EventNames } from "../events/EventNames";
 
@@ -10,7 +10,7 @@ export class BoosterService {
   /** Коллекция зарегистрированных бустеров по их id. */
   private boosters: Record<string, Booster> = {};
 
-  constructor(private bus: ExtendedEventTarget) {}
+  constructor(private bus: EventBus) {}
 
   /**
    * Регистрирует новый бустер.
@@ -42,6 +42,10 @@ export class BoosterService {
     boost.start();
     // Сообщаем подписчикам об активации конкретного бустера
     this.bus.emit(EventNames.BoosterActivated, id);
+    console.debug(
+      "Listeners for BoosterActivated:",
+      this.bus.getListenerCount(EventNames.BoosterActivated),
+    );
   }
 
   /**

--- a/assets/scripts/core/boosters/BoosterService.ts
+++ b/assets/scripts/core/boosters/BoosterService.ts
@@ -1,5 +1,6 @@
 import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
 import type { Booster } from "./Booster";
+import { EventNames } from "../events/EventNames";
 
 /**
  * Хранит все доступные бустеры,
@@ -40,7 +41,7 @@ export class BoosterService {
     // Переводим игру в режим выбора клетки/клеток
     boost.start();
     // Сообщаем подписчикам об активации конкретного бустера
-    this.bus.emit("BoosterActivated", id);
+    this.bus.emit(EventNames.BoosterActivated, id);
   }
 
   /**
@@ -60,7 +61,7 @@ export class BoosterService {
     // Уменьшаем количество зарядов
     boost.charges--;
     // Оповещаем, что заряд израсходован
-    this.bus.emit("BoosterConsumed", id);
+    this.bus.emit(EventNames.BoosterConsumed, id);
   }
 
   /**
@@ -68,6 +69,6 @@ export class BoosterService {
    */
   cancel(): void {
     // Сообщаем слушателям, что активация прервана
-    this.bus.emit("BoosterCancelled");
+    this.bus.emit(EventNames.BoosterCancelled);
   }
 }

--- a/assets/scripts/core/boosters/BoosterService.ts
+++ b/assets/scripts/core/boosters/BoosterService.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import type { Booster } from "./Booster";
 import { EventNames } from "../events/EventNames";
 
@@ -10,7 +10,7 @@ export class BoosterService {
   /** Коллекция зарегистрированных бустеров по их id. */
   private boosters: Record<string, Booster> = {};
 
-  constructor(private bus: EventBus) {}
+  constructor(private bus: InfrastructureEventBus) {}
 
   /**
    * Регистрирует новый бустер.

--- a/assets/scripts/core/boosters/TeleportBooster.ts
+++ b/assets/scripts/core/boosters/TeleportBooster.ts
@@ -1,6 +1,6 @@
 import { Booster } from "./Booster";
 import { Board } from "../board/Board";
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { SwapCommand } from "../board/commands/SwapCommand";
 import { BoardSolver } from "../board/BoardSolver";
 import { EventNames } from "../events/EventNames";
@@ -16,7 +16,7 @@ export class TeleportBooster implements Booster {
   charges: number;
   constructor(
     private board: Board,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     charges: number,
   ) {
     this.charges = charges;

--- a/assets/scripts/core/boosters/TeleportBooster.ts
+++ b/assets/scripts/core/boosters/TeleportBooster.ts
@@ -1,6 +1,6 @@
 import { Booster } from "./Booster";
 import { Board } from "../board/Board";
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { SwapCommand } from "../board/commands/SwapCommand";
 import { BoardSolver } from "../board/BoardSolver";
 import { EventNames } from "../events/EventNames";
@@ -16,7 +16,7 @@ export class TeleportBooster implements Booster {
   charges: number;
   constructor(
     private board: Board,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     charges: number,
   ) {
     this.charges = charges;

--- a/assets/scripts/core/boosters/TeleportBooster.ts
+++ b/assets/scripts/core/boosters/TeleportBooster.ts
@@ -3,6 +3,7 @@ import { Board } from "../board/Board";
 import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
 import { SwapCommand } from "../board/commands/SwapCommand";
 import { BoardSolver } from "../board/BoardSolver";
+import { EventNames } from "../events/EventNames";
 
 /**
  * Teleport booster allows swapping any two tiles.
@@ -36,20 +37,20 @@ export class TeleportBooster implements Booster {
       const solver = new BoardSolver(this.board);
       if (solver.hasMoves()) {
         this.charges--;
-        this.bus.emit("BoosterConsumed", this.id);
+        this.bus.emit(EventNames.BoosterConsumed, this.id);
       } else {
         // Revert the swap when it doesn't yield any moves
         await new SwapCommand(this.board, first, b, this.bus).execute();
-        this.bus.emit("SwapCancelled");
+        this.bus.emit(EventNames.SwapCancelled);
       }
     };
 
     const onFirst = (posA: unknown) => {
       first = posA as cc.Vec2;
-      this.bus.once("GroupSelected", onSecond);
+      this.bus.once(EventNames.GroupSelected, onSecond);
     };
 
     // Wait for the first cell selection
-    this.bus.once("GroupSelected", onFirst);
+    this.bus.once(EventNames.GroupSelected, onFirst);
   }
 }

--- a/assets/scripts/core/events.meta
+++ b/assets/scripts/core/events.meta
@@ -1,0 +1,13 @@
+{
+  "ver": "1.1.3",
+  "uuid": "a777fb0b-93d9-462c-8023-45c941143779",
+  "importer": "folder",
+  "isBundle": false,
+  "bundleName": "",
+  "priority": 1,
+  "compressionType": {},
+  "optimizeHotUpdate": {},
+  "inlineSpriteFrames": {},
+  "isRemoteBundle": {},
+  "subMetas": {}
+}

--- a/assets/scripts/core/events/EventNames.ts
+++ b/assets/scripts/core/events/EventNames.ts
@@ -1,0 +1,35 @@
+/**
+ * Единый источник истины для имен событий.
+ * Используем строковые константы, потому что cc.EventTarget
+ * ожидает строковые имена.
+ */
+export const EventNames = {
+  GameStart: "GameStart",
+  GroupSelected: "GroupSelected",
+  TilesRemoved: "TilesRemoved",
+  MoveCompleted: "MoveCompleted",
+  FillStarted: "FillStarted",
+  FillDone: "FillDone",
+  FallStarted: "FallStarted",
+  FallDone: "FallDone",
+  TurnUsed: "TurnUsed",
+  TurnEnded: "TurnEnded",
+  OutOfTurns: "OutOfTurns",
+  GameWon: "GameWon",
+  GameLost: "GameLost",
+  BoosterActivated: "BoosterActivated",
+  BoosterConsumed: "BoosterConsumed",
+  BoosterCancelled: "BoosterCancelled",
+  StateChanged: "StateChanged",
+  GamePaused: "GamePaused",
+  GameResumed: "GameResumed",
+  AnimationStarted: "AnimationStarted",
+  AnimationEnded: "AnimationEnded",
+  AutoShuffle: "AutoShuffle",
+  ShuffleLimitExceeded: "ShuffleLimitExceeded",
+  ShuffleDone: "ShuffleDone",
+  GroupFound: "GroupFound",
+  SwapCancelled: "SwapCancelled",
+  SwapDone: "SwapDone",
+  RemoveStarted: "RemoveStarted",
+} as const;

--- a/assets/scripts/core/events/EventNames.ts.meta
+++ b/assets/scripts/core/events/EventNames.ts.meta
@@ -1,0 +1,10 @@
+{
+  "ver": "1.1.0",
+  "uuid": "61e1a064-0611-483a-8046-af723681e2d3",
+  "importer": "typescript",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -16,6 +16,7 @@ import { MoveExecutor } from "../board/MoveExecutor";
 import { ScoreStrategy } from "../rules/ScoreStrategy";
 import { TurnManager } from "../rules/TurnManager";
 import { BoardConfig } from "../../config/ConfigLoader";
+import { EventNames } from "../events/EventNames";
 
 /**
  * Finite state machine orchestrating a single game session.
@@ -44,11 +45,13 @@ export class GameStateMachine {
    * Subscribe to relevant events and enter the initial WaitingInput state.
    */
   start(): void {
-    this.bus.on("GroupSelected", (p: cc.Vec2) => this.onGroupSelected(p));
-    this.bus.on("BoosterActivated", () => this.onBoosterActivated());
-    this.bus.on("BoosterConsumed", () => this.onBoosterConsumed());
-    this.bus.on("BoosterCancelled", () => this.onBoosterCancelled());
-    this.bus.on("MoveCompleted", () => this.onMoveCompleted());
+    this.bus.on(EventNames.GroupSelected, (p: cc.Vec2) =>
+      this.onGroupSelected(p),
+    );
+    this.bus.on(EventNames.BoosterActivated, () => this.onBoosterActivated());
+    this.bus.on(EventNames.BoosterConsumed, () => this.onBoosterConsumed());
+    this.bus.on(EventNames.BoosterCancelled, () => this.onBoosterCancelled());
+    this.bus.on(EventNames.MoveCompleted, () => this.onMoveCompleted());
     this.changeState("WaitingInput");
   }
 
@@ -141,12 +144,12 @@ export class GameStateMachine {
    */
   private changeState(newState: GameState): void {
     this.state = newState;
-    this.bus.emit("StateChanged", newState);
+    this.bus.emit(EventNames.StateChanged, newState);
     if (newState === "Win") {
-      this.bus.emit("GameWon", this.score);
+      this.bus.emit(EventNames.GameWon, this.score);
     }
     if (newState === "Lose") {
-      this.bus.emit("GameLost", this.score);
+      this.bus.emit(EventNames.GameLost, this.score);
     }
   }
 

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -57,6 +57,7 @@ export class GameStateMachine {
       this.bus.getListenerCount(EventNames.GroupSelected),
     );
     this.changeState("WaitingInput");
+    console.info("FSM started, current state: WaitingInput");
   }
 
   /**
@@ -64,7 +65,11 @@ export class GameStateMachine {
    * Ignored unless the machine awaits input.
    */
   private onGroupSelected(start: cc.Vec2): void {
+    console.info("FSM received GroupSelected at", start);
     if (this.state !== "WaitingInput") {
+      console.info(
+        `Ignored GroupSelected because current state is ${this.state}`,
+      );
       // Ignore input while another action is executing
       return;
     }
@@ -149,6 +154,7 @@ export class GameStateMachine {
   private changeState(newState: GameState): void {
     this.state = newState;
     this.bus.emit(EventNames.StateChanged, newState);
+    console.info("State changed to", newState);
     if (newState === "Win") {
       this.bus.emit(EventNames.GameWon, this.score);
     }

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -9,7 +9,7 @@ export type GameState =
   | "Win"
   | "Lose";
 
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { Board } from "../board/Board";
 import { BoardSolver } from "../board/BoardSolver";
 import { MoveExecutor } from "../board/MoveExecutor";
@@ -31,7 +31,7 @@ export class GameStateMachine {
   private shuffles = 0;
 
   constructor(
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
     private board: Board,
     private solver: BoardSolver,
     private executor: MoveExecutor,
@@ -52,6 +52,10 @@ export class GameStateMachine {
     this.bus.on(EventNames.BoosterConsumed, () => this.onBoosterConsumed());
     this.bus.on(EventNames.BoosterCancelled, () => this.onBoosterCancelled());
     this.bus.on(EventNames.MoveCompleted, () => this.onMoveCompleted());
+    console.debug(
+      "Listeners for GroupSelected:",
+      this.bus.getListenerCount(EventNames.GroupSelected),
+    );
     this.changeState("WaitingInput");
   }
 

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -9,7 +9,7 @@ export type GameState =
   | "Win"
   | "Lose";
 
-import { EventBus } from "../../infrastructure/EventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { Board } from "../board/Board";
 import { BoardSolver } from "../board/BoardSolver";
 import { MoveExecutor } from "../board/MoveExecutor";
@@ -31,7 +31,7 @@ export class GameStateMachine {
   private shuffles = 0;
 
   constructor(
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
     private board: Board,
     private solver: BoardSolver,
     private executor: MoveExecutor,

--- a/assets/scripts/core/rules/TurnManager.ts
+++ b/assets/scripts/core/rules/TurnManager.ts
@@ -1,4 +1,4 @@
-import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventBus } from "../../infrastructure/EventBus";
 import { EventNames } from "../events/EventNames";
 export class TurnManager {
   /** Remaining turns in the current session. */
@@ -11,7 +11,7 @@ export class TurnManager {
    */
   constructor(
     initialTurns: number,
-    private bus: ExtendedEventTarget,
+    private bus: EventBus,
   ) {
     this.turnsLeft = initialTurns;
   }

--- a/assets/scripts/core/rules/TurnManager.ts
+++ b/assets/scripts/core/rules/TurnManager.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../infrastructure/EventBus";
+import { EventBus } from "../../infrastructure/InfrastructureEventBus";
 import { EventNames } from "../events/EventNames";
 export class TurnManager {
   /** Remaining turns in the current session. */

--- a/assets/scripts/core/rules/TurnManager.ts
+++ b/assets/scripts/core/rules/TurnManager.ts
@@ -1,4 +1,5 @@
 import { ExtendedEventTarget } from "../../infrastructure/ExtendedEventTarget";
+import { EventNames } from "../events/EventNames";
 export class TurnManager {
   /** Remaining turns in the current session. */
   private turnsLeft: number;
@@ -23,9 +24,9 @@ export class TurnManager {
    */
   useTurn(): void {
     this.turnsLeft--;
-    this.bus.emit("TurnUsed", this.turnsLeft);
+    this.bus.emit(EventNames.TurnUsed, this.turnsLeft);
     if (this.turnsLeft === 0) {
-      this.bus.emit("OutOfTurns");
+      this.bus.emit(EventNames.OutOfTurns);
     }
   }
 

--- a/assets/scripts/core/rules/TurnManager.ts
+++ b/assets/scripts/core/rules/TurnManager.ts
@@ -1,4 +1,4 @@
-import { EventBus } from "../../infrastructure/InfrastructureEventBus";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
 import { EventNames } from "../events/EventNames";
 export class TurnManager {
   /** Remaining turns in the current session. */
@@ -11,7 +11,7 @@ export class TurnManager {
    */
   constructor(
     initialTurns: number,
-    private bus: EventBus,
+    private bus: InfrastructureEventBus,
   ) {
     this.turnsLeft = initialTurns;
   }

--- a/assets/scripts/infrastructure/EventBus.ts
+++ b/assets/scripts/infrastructure/EventBus.ts
@@ -1,1 +1,84 @@
-export { EventBus } from "../core/EventBus";
+export class EventBus {
+  private target = new cc.EventTarget();
+  private registry: Map<string, Set<(...args: unknown[]) => void>> = new Map();
+
+  on(
+    eventName: string,
+    handler: (...args: unknown[]) => void,
+    target?: unknown,
+    useCapture?: boolean,
+  ): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.target as any).on(eventName, handler, target, useCapture);
+    let set = this.registry.get(eventName);
+    if (!set) {
+      set = new Set();
+      this.registry.set(eventName, set);
+    }
+    set.add(handler);
+  }
+
+  off(
+    eventName: string,
+    handler?: (...args: unknown[]) => void,
+    target?: unknown,
+  ): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.target as any).off(eventName, handler, target);
+    const set = this.registry.get(eventName);
+    if (set && handler) {
+      set.delete(handler);
+      if (set.size === 0) {
+        this.registry.delete(eventName);
+      }
+    } else if (set && !handler) {
+      this.registry.delete(eventName);
+    }
+  }
+
+  once(
+    event: string,
+    listener: (...args: unknown[]) => void,
+    target?: unknown,
+  ): void {
+    const callback = (...args: unknown[]) => {
+      this.off(event, callback, target);
+      listener(...args);
+    };
+    this.on(event, callback, target);
+  }
+
+  emit(eventName: string, ...args: unknown[]): void {
+    const count = this.getListenerCount(eventName);
+    if (count === 0) {
+      console.warn(
+        `EventBus: emitted event '${eventName}' has no listeners (possible typo or initialization issue)`,
+      );
+      if (typeof CC_DEBUG !== "undefined" && CC_DEBUG) {
+        console.warn(new Error().stack);
+      }
+    }
+    this.target.emit(eventName, ...args);
+  }
+
+  getListenerCount(eventName: string): number {
+    return this.registry.get(eventName)?.size ?? 0;
+  }
+
+  clear(eventName?: string): void {
+    if (eventName) {
+      const set = this.registry.get(eventName);
+      if (set) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        set.forEach((h) => (this.target as any).off(eventName, h));
+      }
+      this.registry.delete(eventName);
+    } else {
+      this.registry.forEach((handlers, evt) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handlers.forEach((h) => (this.target as any).off(evt, h));
+      });
+      this.registry.clear();
+    }
+  }
+}

--- a/assets/scripts/infrastructure/InfrastructureEventBus.ts
+++ b/assets/scripts/infrastructure/InfrastructureEventBus.ts
@@ -1,4 +1,4 @@
-export class EventBus {
+export class InfrastructureEventBus {
   private target = new cc.EventTarget();
   private registry: Map<string, Set<(...args: unknown[]) => void>> = new Map();
 

--- a/assets/scripts/infrastructure/InfrastructureEventBus.ts.meta
+++ b/assets/scripts/infrastructure/InfrastructureEventBus.ts.meta
@@ -1,6 +1,6 @@
 {
   "ver": "1.1.0",
-  "uuid": "a2bf3565-9dd0-480f-b82b-9e89dcb6f83c",
+  "uuid": "2c14273c-a4e5-4bb9-8a4b-a742a5a15bae",
   "importer": "typescript",
   "isPlugin": false,
   "loadPluginInWeb": true,

--- a/assets/scripts/ui/GameSceneController.ts
+++ b/assets/scripts/ui/GameSceneController.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../core/EventBus";
+import { EventNames } from "../core/events/EventNames";
 const { ccclass } = cc._decorator;
 
 interface NodeUtils {
@@ -25,12 +26,12 @@ export class GameSceneController extends cc.Component {
     } | null;
     if (this.popup?.node) this.popup.node.active = false;
 
-    EventBus.on("GamePaused", () => {
+    EventBus.on(EventNames.GamePaused, () => {
       cc.director.pause();
       if (this.popup?.node) this.popup.node.active = true;
     });
 
-    EventBus.on("GameResumed", () => {
+    EventBus.on(EventNames.GameResumed, () => {
       cc.director.resume();
       if (this.popup?.node) this.popup.node.active = false;
     });

--- a/assets/scripts/ui/HudController.ts
+++ b/assets/scripts/ui/HudController.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../core/EventBus";
+import { EventNames } from "../core/events/EventNames";
 const { ccclass } = cc._decorator;
 
 interface NodeUtils {
@@ -51,22 +52,22 @@ export class HudController extends cc.Component {
       ?.getComponent("Button") as NodeUtils | null;
 
     // Update moves counter when a turn is consumed
-    EventBus.on("TurnUsed", (left: number) => {
+    EventBus.on(EventNames.TurnUsed, (left: number) => {
       if (this.lblMoves) this.lblMoves.string = String(left);
       const moveNode = this.lblMoves?.node as unknown as NodeUtils | undefined;
       if (left <= 3 && moveNode?.runAction) {
-        EventBus.emit("AnimationStarted", "moves-shake");
+        EventBus.emit(EventNames.AnimationStarted, "moves-shake");
         moveNode.runAction(shake);
-        EventBus.emit("AnimationEnded", "moves-shake");
+        EventBus.emit(EventNames.AnimationEnded, "moves-shake");
       }
     });
 
     // Update score display after a turn ends
-    EventBus.on("TurnEnded", ({ score }: { score: number }) => {
+    EventBus.on(EventNames.TurnEnded, ({ score }: { score: number }) => {
       if (!this.lblScore) return;
       const startVal = parseInt(this.lblScore.string, 10) || 0;
       const data = { value: startVal };
-      EventBus.emit("AnimationStarted", "score-tween");
+      EventBus.emit(EventNames.AnimationStarted, "score-tween");
       // Tween over half a second using an ease-out curve for smooth feel
       cc.tween(data).to(0.5, { value: score }, { easing: "quadOut" }).start();
       const id = setInterval(() => {
@@ -76,28 +77,28 @@ export class HudController extends cc.Component {
       setTimeout(() => {
         clearInterval(id);
         if (this.lblScore) this.lblScore.string = String(score);
-        EventBus.emit("AnimationEnded", "score-tween");
+        EventBus.emit(EventNames.AnimationEnded, "score-tween");
       }, 500);
     });
 
     // Booster and pause button interactions
     this.btnBomb?.node?.on("click", () => {
-      EventBus.emit("BoosterActivated", "bomb");
+      EventBus.emit(EventNames.BoosterActivated, "bomb");
     });
     this.btnSwap?.node?.on("click", () => {
-      EventBus.emit("BoosterActivated", "swap");
+      EventBus.emit(EventNames.BoosterActivated, "swap");
     });
     this.btnPause?.node?.on("click", () => {
-      EventBus.emit("GamePaused");
+      EventBus.emit(EventNames.GamePaused);
     });
 
-    EventBus.on("BoosterActivated", (name: string) => {
+    EventBus.on(EventNames.BoosterActivated, (name: string) => {
       const btn =
         name === "bomb" ? this.btnBomb : name === "swap" ? this.btnSwap : null;
       if (btn?.node?.runAction) {
-        EventBus.emit("AnimationStarted", "booster-pulse");
+        EventBus.emit(EventNames.AnimationStarted, "booster-pulse");
         btn.node.runAction(pulse);
-        EventBus.emit("AnimationEnded", "booster-pulse");
+        EventBus.emit(EventNames.AnimationEnded, "booster-pulse");
       }
     });
   }

--- a/assets/scripts/ui/PopupController.ts
+++ b/assets/scripts/ui/PopupController.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../core/EventBus";
+import { EventNames } from "../core/events/EventNames";
 const { ccclass } = cc._decorator;
 
 /**
@@ -16,13 +17,15 @@ export class PopupController extends cc.Component {
   btnRestart!: { node: { once: (event: string, cb: () => void) => void } };
 
   onEnable(): void {
-    EventBus.on("GameWon", (score: number) => this.show(true, score));
-    EventBus.on("GameLost", (score: number) => this.show(false, score));
+    EventBus.on(EventNames.GameWon, (score: number) => this.show(true, score));
+    EventBus.on(EventNames.GameLost, (score: number) =>
+      this.show(false, score),
+    );
   }
 
   onDisable(): void {
-    EventBus.off("GameWon");
-    EventBus.off("GameLost");
+    EventBus.off(EventNames.GameWon);
+    EventBus.off(EventNames.GameLost);
   }
 
   /**

--- a/assets/scripts/ui/PopupPause.ts
+++ b/assets/scripts/ui/PopupPause.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../core/EventBus";
+import { EventNames } from "../core/events/EventNames";
 const { ccclass } = cc._decorator;
 
 interface NodeUtils {
@@ -27,7 +28,7 @@ export class PopupPause extends cc.Component {
       ?.getComponent("Button") as NodeUtils | null;
 
     this.btnResume?.node?.on("click", () => {
-      EventBus.emit("GameResumed");
+      EventBus.emit(EventNames.GameResumed);
     });
     this.btnRestart?.node?.on("click", () => {
       cc.director.loadScene("GameScene");

--- a/assets/scripts/ui/controllers/GameBoardController.ts
+++ b/assets/scripts/ui/controllers/GameBoardController.ts
@@ -43,6 +43,10 @@ export default class GameBoardController extends cc.Component {
 
   /** Board model generated on load. */
   private board!: Board;
+
+  getBoard(): Board {
+    return this.board;
+  }
   /** Matrix of view components mirroring board state. */
   tileViews: TileView[][] = [];
 

--- a/assets/scripts/ui/controllers/MoveFlowController.ts
+++ b/assets/scripts/ui/controllers/MoveFlowController.ts
@@ -1,6 +1,7 @@
 const { ccclass, property } = cc._decorator;
 
 import { EventBus as bus } from "../../core/EventBus";
+import { EventNames } from "../../core/events/EventNames";
 import GameBoardController from "./GameBoardController";
 import TileView from "../views/TileView";
 import { loadBoardConfig } from "../../config/ConfigLoader";
@@ -20,9 +21,9 @@ export default class MoveFlowController extends cc.Component {
     this.tileViews = board.tileViews;
 
     // Listen for core events signalling board updates
-    bus.on("TilesRemoved", this.onRemove, this);
-    bus.on("FallStarted", this.onFall, this);
-    bus.on("FillStarted", this.onFill, this);
+    bus.on(EventNames.TilesRemoved, this.onRemove, this);
+    bus.on(EventNames.FallStarted, this.onFall, this);
+    bus.on(EventNames.FillStarted, this.onFill, this);
   }
 
   /**

--- a/assets/scripts/ui/controllers/TileInputController.ts
+++ b/assets/scripts/ui/controllers/TileInputController.ts
@@ -29,6 +29,10 @@ export default class TileInputController extends cc.Component {
         );
         bus.emit(EventNames.GroupSelected, { x: col, y: row });
         console.log("GroupSelected", { x: col, y: row });
+        console.debug(
+          "Listeners for GroupSelected:",
+          bus.getListenerCount(EventNames.GroupSelected),
+        );
       },
       this,
     );

--- a/assets/scripts/ui/controllers/TileInputController.ts
+++ b/assets/scripts/ui/controllers/TileInputController.ts
@@ -2,6 +2,7 @@ const { ccclass } = cc._decorator;
 
 import { loadBoardConfig } from "../../config/ConfigLoader";
 import { EventBus as bus } from "../../core/EventBus";
+import { EventNames } from "../../core/events/EventNames";
 
 @ccclass()
 export default class TileInputController extends cc.Component {
@@ -26,7 +27,7 @@ export default class TileInputController extends cc.Component {
           (this.node.height / 2 - (local.y - 12)) /
             loadBoardConfig().tileHeight,
         );
-        bus.emit("GroupSelected", { x: col, y: row });
+        bus.emit(EventNames.GroupSelected, { x: col, y: row });
         console.log("GroupSelected", { x: col, y: row });
       },
       this,

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ This executes the Jest suite defined in the `tests` folder.
 ## Events
 
 All engine-wide events are defined in [`EventNames.ts`](assets/scripts/core/events/EventNames.ts). Use these constants when emitting or subscribing instead of string literals.
+The global `EventBus` tracks listeners and warns in development when an emitted event has no subscribers.
 
 ## QA
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,10 @@ npm test
 
 This executes the Jest suite defined in the `tests` folder.
 
+## Events
+
+All engine-wide events are defined in [`EventNames.ts`](assets/scripts/core/events/EventNames.ts). Use these constants when emitting or subscribing instead of string literals.
+
 ## QA
 
 For manual mobile checks see the [UI Test Checklist](docs/UI_TEST_CHECKLIST.md).

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,10 @@ This executes the Jest suite defined in the `tests` folder.
 All engine-wide events are defined in [`EventNames.ts`](assets/scripts/core/events/EventNames.ts). Use these constants when emitting or subscribing instead of string literals.
 The global `EventBus` tracks listeners and warns in development when an emitted event has no subscribers.
 
+## FSM integration
+
+`GameScene.ts` composes the core classes and starts the `GameStateMachine` when the scene loads. See `tools/fsm-smoke.ts` for a minimal script demonstrating the event flow from user input to state transitions.
+
 ## QA
 
 For manual mobile checks see the [UI Test Checklist](docs/UI_TEST_CHECKLIST.md).

--- a/tests/GameStateMachine.spec.ts
+++ b/tests/GameStateMachine.spec.ts
@@ -1,4 +1,5 @@
 import { EventBus } from "../assets/scripts/core/EventBus";
+import { EventNames } from "../assets/scripts/core/events/EventNames";
 import {
   GameStateMachine,
   GameState,
@@ -51,7 +52,7 @@ describe("GameStateMachine", () => {
   test("start emits WaitingInput", () => {
     const fsm = createFSM();
     const states: GameState[] = [];
-    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    EventBus.on(EventNames.StateChanged, (s: GameState) => states.push(s));
     fsm.start();
     expect(states).toEqual(["WaitingInput"]);
   });
@@ -59,9 +60,9 @@ describe("GameStateMachine", () => {
   test("group selection performs full move sequence", async () => {
     const fsm = createFSM();
     const states: GameState[] = [];
-    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    EventBus.on(EventNames.StateChanged, (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
+    EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     expect(states.slice(0, 5)).toEqual([
       "WaitingInput",
@@ -75,9 +76,9 @@ describe("GameStateMachine", () => {
   test("win when reaching target score", async () => {
     const fsm = createFSM(5); // easy target
     const states: GameState[] = [];
-    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    EventBus.on(EventNames.StateChanged, (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
+    EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     expect(states).toContain("Win");
   });
@@ -94,9 +95,9 @@ describe("GameStateMachine", () => {
     const board = new Board(singleCfg, [[TileFactory.createNormal("red")]]);
     const fsm = createFSM(20, board);
     const states: GameState[] = [];
-    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    EventBus.on(EventNames.StateChanged, (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
+    EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
     await new Promise((r) => setImmediate(r));
     const lastTwo = states.slice(-2);
     expect(lastTwo).toEqual(["Shuffle", "WaitingInput"]);
@@ -105,10 +106,10 @@ describe("GameStateMachine", () => {
   test("input ignored during execution", () => {
     const fsm = createFSM();
     const states: GameState[] = [];
-    EventBus.on("StateChanged", (s: GameState) => states.push(s));
+    EventBus.on(EventNames.StateChanged, (s: GameState) => states.push(s));
     fsm.start();
-    EventBus.emit("GroupSelected", new cc.Vec2(0, 0));
-    EventBus.emit("GroupSelected", new cc.Vec2(0, 1));
+    EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
+    EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 1));
     expect(states.filter((s) => s === "ExecutingMove")).toHaveLength(1);
   });
 });

--- a/tests/MoveExecutor.spec.ts
+++ b/tests/MoveExecutor.spec.ts
@@ -2,6 +2,7 @@ import { Board } from "../assets/scripts/core/board/Board";
 import { BoardConfig } from "../assets/scripts/config/ConfigLoader";
 import { TileFactory } from "../assets/scripts/core/board/Tile";
 import { EventBus } from "../assets/scripts/core/EventBus";
+import { EventNames } from "../assets/scripts/core/events/EventNames";
 import { MoveExecutor } from "../assets/scripts/core/board/MoveExecutor";
 
 describe("MoveExecutor", () => {
@@ -27,18 +28,22 @@ describe("MoveExecutor", () => {
     const executor = new MoveExecutor(board, EventBus);
 
     const events: string[] = [];
-    EventBus.on("removeDone", () => events.push("removeDone"));
-    EventBus.on("fallDone", () => events.push("fallDone"));
-    EventBus.on("fillDone", () => events.push("fillDone"));
-    EventBus.on("MoveCompleted", () => events.push("MoveCompleted"));
+    EventBus.on(EventNames.TilesRemoved, () =>
+      events.push(EventNames.TilesRemoved),
+    );
+    EventBus.on(EventNames.FallDone, () => events.push(EventNames.FallDone));
+    EventBus.on(EventNames.FillDone, () => events.push(EventNames.FillDone));
+    EventBus.on(EventNames.MoveCompleted, () =>
+      events.push(EventNames.MoveCompleted),
+    );
 
     await executor.execute([new cc.Vec2(0, 1), new cc.Vec2(1, 1)]);
 
     expect(events).toEqual([
-      "removeDone",
-      "fallDone",
-      "fillDone",
-      "MoveCompleted",
+      EventNames.TilesRemoved,
+      EventNames.FallDone,
+      EventNames.FillDone,
+      EventNames.MoveCompleted,
     ]);
   });
 

--- a/tests/ShuffleService.spec.ts
+++ b/tests/ShuffleService.spec.ts
@@ -4,6 +4,7 @@ import { BoardSolver } from "../assets/scripts/core/board/BoardSolver";
 import { TileFactory } from "../assets/scripts/core/board/Tile";
 import { ShuffleService } from "../assets/scripts/core/board/ShuffleService";
 import { BoardConfig } from "../assets/scripts/config/ConfigLoader";
+import { EventNames } from "../assets/scripts/core/events/EventNames";
 
 describe("ShuffleService", () => {
   const cfgNoMoves: BoardConfig = {
@@ -34,10 +35,14 @@ describe("ShuffleService", () => {
     const service = new ShuffleService(board, solver, EventBus, 3);
 
     const events: string[] = [];
-    EventBus.on("AutoShuffle", () => events.push("AutoShuffle"));
-    EventBus.on("ShuffleDone", () => events.push("ShuffleDone"));
-    EventBus.on("ShuffleLimitExceeded", () => {
-      events.push("ShuffleLimitExceeded");
+    EventBus.on(EventNames.AutoShuffle, () =>
+      events.push(EventNames.AutoShuffle),
+    );
+    EventBus.on(EventNames.ShuffleDone, () =>
+      events.push(EventNames.ShuffleDone),
+    );
+    EventBus.on(EventNames.ShuffleLimitExceeded, () => {
+      events.push(EventNames.ShuffleLimitExceeded);
     });
 
     service.ensureMoves();
@@ -49,13 +54,13 @@ describe("ShuffleService", () => {
     service.ensureMoves();
 
     expect(events).toEqual([
-      "AutoShuffle",
-      "ShuffleDone",
-      "AutoShuffle",
-      "ShuffleDone",
-      "AutoShuffle",
-      "ShuffleDone",
-      "ShuffleLimitExceeded",
+      EventNames.AutoShuffle,
+      EventNames.ShuffleDone,
+      EventNames.AutoShuffle,
+      EventNames.ShuffleDone,
+      EventNames.AutoShuffle,
+      EventNames.ShuffleDone,
+      EventNames.ShuffleLimitExceeded,
     ]);
   });
 
@@ -67,10 +72,14 @@ describe("ShuffleService", () => {
     const service = new ShuffleService(board, solver, EventBus, 3);
 
     const events: string[] = [];
-    EventBus.on("AutoShuffle", () => events.push("AutoShuffle"));
-    EventBus.on("ShuffleDone", () => events.push("ShuffleDone"));
-    EventBus.on("ShuffleLimitExceeded", () =>
-      events.push("ShuffleLimitExceeded"),
+    EventBus.on(EventNames.AutoShuffle, () =>
+      events.push(EventNames.AutoShuffle),
+    );
+    EventBus.on(EventNames.ShuffleDone, () =>
+      events.push(EventNames.ShuffleDone),
+    );
+    EventBus.on(EventNames.ShuffleLimitExceeded, () =>
+      events.push(EventNames.ShuffleLimitExceeded),
     );
 
     service.ensureMoves();

--- a/tests/TurnManager.spec.ts
+++ b/tests/TurnManager.spec.ts
@@ -1,11 +1,11 @@
 // Тесты больше не используют eventemitter2, вместо него наш EventBus
-import { ExtendedEventTarget } from "../assets/scripts/infrastructure/ExtendedEventTarget";
+import { EventBus } from "../assets/scripts/infrastructure/EventBus";
 import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
 import { EventNames } from "../assets/scripts/core/events/EventNames";
 
 describe("TurnManager", () => {
   test("counts down turns and emits TurnUsed", () => {
-    const bus = new ExtendedEventTarget();
+    const bus = new EventBus();
     const tm = new TurnManager(5, bus);
     const used: number[] = [];
     bus.on(EventNames.TurnUsed, (left) => used.push(left as number));
@@ -17,7 +17,7 @@ describe("TurnManager", () => {
   });
 
   test("OutOfTurns emitted when reaching zero", () => {
-    const bus = new ExtendedEventTarget();
+    const bus = new EventBus();
     const tm = new TurnManager(2, bus);
     let count = 0;
     bus.on(EventNames.OutOfTurns, () => count++);

--- a/tests/TurnManager.spec.ts
+++ b/tests/TurnManager.spec.ts
@@ -1,11 +1,11 @@
 // Тесты больше не используют eventemitter2, вместо него наш EventBus
-import { EventBus } from "../assets/scripts/infrastructure/EventBus";
+import { InfrastructureEventBus } from "../assets/scripts/infrastructure/InfrastructureEventBus";
 import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
 import { EventNames } from "../assets/scripts/core/events/EventNames";
 
 describe("TurnManager", () => {
   test("counts down turns and emits TurnUsed", () => {
-    const bus = new EventBus();
+    const bus = new InfrastructureEventBus();
     const tm = new TurnManager(5, bus);
     const used: number[] = [];
     bus.on(EventNames.TurnUsed, (left) => used.push(left as number));
@@ -17,7 +17,7 @@ describe("TurnManager", () => {
   });
 
   test("OutOfTurns emitted when reaching zero", () => {
-    const bus = new EventBus();
+    const bus = new InfrastructureEventBus();
     const tm = new TurnManager(2, bus);
     let count = 0;
     bus.on(EventNames.OutOfTurns, () => count++);

--- a/tests/TurnManager.spec.ts
+++ b/tests/TurnManager.spec.ts
@@ -1,13 +1,14 @@
 // Тесты больше не используют eventemitter2, вместо него наш EventBus
 import { ExtendedEventTarget } from "../assets/scripts/infrastructure/ExtendedEventTarget";
 import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
+import { EventNames } from "../assets/scripts/core/events/EventNames";
 
 describe("TurnManager", () => {
   test("counts down turns and emits TurnUsed", () => {
     const bus = new ExtendedEventTarget();
     const tm = new TurnManager(5, bus);
     const used: number[] = [];
-    bus.on("TurnUsed", (left) => used.push(left as number));
+    bus.on(EventNames.TurnUsed, (left) => used.push(left as number));
     tm.useTurn();
     tm.useTurn();
     tm.useTurn();
@@ -19,7 +20,7 @@ describe("TurnManager", () => {
     const bus = new ExtendedEventTarget();
     const tm = new TurnManager(2, bus);
     let count = 0;
-    bus.on("OutOfTurns", () => count++);
+    bus.on(EventNames.OutOfTurns, () => count++);
     tm.useTurn();
     expect(count).toBe(0);
     tm.useTurn();

--- a/tools/fsm-smoke.ts
+++ b/tools/fsm-smoke.ts
@@ -1,0 +1,34 @@
+import { Board } from "../assets/scripts/core/board/Board";
+import { BoardGenerator } from "../assets/scripts/core/board/BoardGenerator";
+import { BoardSolver } from "../assets/scripts/core/board/BoardSolver";
+import { MoveExecutor } from "../assets/scripts/core/board/MoveExecutor";
+import { ScoreStrategyQuadratic } from "../assets/scripts/core/rules/ScoreStrategyQuadratic";
+import { TurnManager } from "../assets/scripts/core/rules/TurnManager";
+import { GameStateMachine } from "../assets/scripts/core/game/GameStateMachine";
+import { EventBus } from "../assets/scripts/core/EventBus";
+import { EventNames } from "../assets/scripts/core/events/EventNames";
+import { DefaultBoard } from "../assets/scripts/config/ConfigLoader";
+
+const board: Board = new BoardGenerator().generate(DefaultBoard);
+const solver = new BoardSolver(board);
+const executor = new MoveExecutor(board, EventBus);
+const score = new ScoreStrategyQuadratic(1);
+const turns = new TurnManager(5, EventBus);
+const fsm = new GameStateMachine(
+  EventBus,
+  board,
+  solver,
+  executor,
+  score,
+  turns,
+  50,
+  2,
+);
+
+EventBus.on(EventNames.StateChanged, (s: string) => console.log("State:", s));
+EventBus.on(EventNames.GroupSelected, (p: cc.Vec2) =>
+  console.log("Emitted group", p),
+);
+
+fsm.start();
+EventBus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));

--- a/types/cc.d.ts
+++ b/types/cc.d.ts
@@ -52,8 +52,8 @@ declare namespace cc {
 
   class EventTarget {
     private listeners: Record<string, ((...args: any[]) => void)[]>;
-    on(event: string, cb: (...args: any[]) => void): void;
-    off(event: string, cb: (...args: any[]) => void): void;
+    on(event: string, cb: (...args: any[]) => void, target?: any): void;
+    off(event: string, cb: (...args: any[]) => void, target?: any): void;
     emit(event: string, ...args: any[]): void;
     clear(event?: string): void;
   }


### PR DESCRIPTION
## Summary
- declare shared event constants in `EventNames.ts`
- reference `EventNames` in game logic and UI
- adjust tests to use the new constants
- document event list in README and architecture notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b5377c0c08320abff632d362e3bdd