### PR TITLE
refactor: centralize booster registration

### DIFF
--- a/__tests__/config/BoosterLimits.spec.ts
+++ b/__tests__/config/BoosterLimits.spec.ts
@@ -2,6 +2,7 @@ import {
   loadBoosterLimits,
   DefaultBoosterLimits,
 } from "../../assets/scripts/config/ConfigLoader";
+import { BoosterRegistry } from "../../assets/scripts/core/boosters/BoosterRegistry";
 
 describe("loadBoosterLimits", () => {
   beforeEach(() => {
@@ -26,14 +27,12 @@ describe("loadBoosterLimits", () => {
     ).localStorage = {
       getItem: () => JSON.stringify({ maxTypes: 3, maxPerType: { bomb: 5 } }),
     };
+    const expected = Object.fromEntries(
+      BoosterRegistry.map((b) => [b.id, b.id === "bomb" ? 5 : 10]),
+    );
     expect(loadBoosterLimits()).toEqual({
       maxTypes: 3,
-      maxPerType: {
-        teleport: 10,
-        superRow: 10,
-        superCol: 10,
-        bomb: 5,
-      },
+      maxPerType: expected,
     });
   });
 });

--- a/assets/scripts/GameScene.ts
+++ b/assets/scripts/GameScene.ts
@@ -9,6 +9,7 @@ import { MoveSequenceLogger } from "./core/diagnostics/MoveSequenceLogger";
 import { initBoosterService } from "./core/boosters/BoosterSetup";
 import { EventNames } from "./core/events/EventNames";
 import BoosterSelectController from "./ui/controllers/BoosterSelectController";
+import { BoosterRegistry } from "./core/boosters/BoosterRegistry";
 
 const { ccclass } = cc._decorator;
 
@@ -68,12 +69,8 @@ export default class GameScene extends cc.Component {
       (selector.node as unknown as { active: boolean }).active = true;
     } else {
       // If no selector exists, auto-select zero boosters to proceed
-      EventBus.emit(EventNames.BoostersSelected, {
-        teleport: 0,
-        superCol: 0,
-        superRow: 0,
-        bomb: 0,
-      });
+      const empty = Object.fromEntries(BoosterRegistry.map((b) => [b.id, 0]));
+      EventBus.emit(EventNames.BoostersSelected, empty);
     }
   }
 }

--- a/assets/scripts/config/ConfigLoader.ts
+++ b/assets/scripts/config/ConfigLoader.ts
@@ -1,3 +1,5 @@
+import { BoosterRegistry } from "../core/boosters/BoosterRegistry";
+
 /**
  * BoardConfig описывает параметры игрового поля: количество колонок и строк,
  * размер тайла, список возможных цветов и порог создания супер-тайла.
@@ -55,23 +57,13 @@ export interface BoosterLimitConfig {
   /** Максимальное число различных типов бустеров, которые можно взять. */
   maxTypes: number;
   /** Лимиты по каждому типу бустера. */
-  maxPerType: {
-    teleport: number;
-    superRow: number;
-    superCol: number;
-    bomb: number;
-  };
+  maxPerType: Record<string, number>;
 }
 
 /** Значения по умолчанию для выбора бустеров. */
 export const DefaultBoosterLimits: BoosterLimitConfig = {
   maxTypes: 2,
-  maxPerType: {
-    teleport: 10,
-    superRow: 10,
-    superCol: 10,
-    bomb: 10,
-  },
+  maxPerType: Object.fromEntries(BoosterRegistry.map((b) => [b.id, 10])),
 };
 
 /** Загружает настройки лимитов бустеров из localStorage. */
@@ -80,20 +72,14 @@ export function loadBoosterLimits(): BoosterLimitConfig {
   if (!raw) return DefaultBoosterLimits;
   try {
     const parsed = JSON.parse(raw) as Partial<BoosterLimitConfig>;
+    const maxPerType = Object.assign(
+      {},
+      DefaultBoosterLimits.maxPerType,
+      parsed.maxPerType,
+    );
     return {
       maxTypes: parsed.maxTypes ?? DefaultBoosterLimits.maxTypes,
-      maxPerType: {
-        teleport:
-          parsed.maxPerType?.teleport ??
-          DefaultBoosterLimits.maxPerType.teleport,
-        superRow:
-          parsed.maxPerType?.superRow ??
-          DefaultBoosterLimits.maxPerType.superRow,
-        superCol:
-          parsed.maxPerType?.superCol ??
-          DefaultBoosterLimits.maxPerType.superCol,
-        bomb: parsed.maxPerType?.bomb ?? DefaultBoosterLimits.maxPerType.bomb,
-      },
+      maxPerType,
     };
   } catch {
     return DefaultBoosterLimits;

--- a/assets/scripts/core/boosters/BoosterRegistry.ts
+++ b/assets/scripts/core/boosters/BoosterRegistry.ts
@@ -1,0 +1,68 @@
+import { Board } from "../board/Board";
+import TileView from "../../ui/views/TileView";
+import { InfrastructureEventBus } from "../../infrastructure/InfrastructureEventBus";
+import { BoosterService } from "./BoosterService";
+import { Booster } from "./Booster";
+import { TeleportBooster } from "./TeleportBooster";
+import { SuperTileBooster } from "./SuperTileBooster";
+import { TileKind } from "../board/Tile";
+
+export interface BoosterFactoryParams {
+  board: Board;
+  views: TileView[][];
+  bus: InfrastructureEventBus;
+  boosterService: BoosterService;
+  charges: number;
+}
+
+export interface BoosterDefinition {
+  id: string;
+  factory: (params: BoosterFactoryParams) => Booster;
+}
+
+export const BoosterRegistry: BoosterDefinition[] = [
+  {
+    id: "teleport",
+    factory: ({ board, bus, charges }) =>
+      new TeleportBooster(board, bus, charges),
+  },
+  {
+    id: "bomb",
+    factory: ({ board, views, bus, boosterService, charges }) =>
+      new SuperTileBooster(
+        "bomb",
+        board,
+        views,
+        bus,
+        boosterService,
+        charges,
+        TileKind.SuperBomb,
+      ),
+  },
+  {
+    id: "superRow",
+    factory: ({ board, views, bus, boosterService, charges }) =>
+      new SuperTileBooster(
+        "superRow",
+        board,
+        views,
+        bus,
+        boosterService,
+        charges,
+        TileKind.SuperRow,
+      ),
+  },
+  {
+    id: "superCol",
+    factory: ({ board, views, bus, boosterService, charges }) =>
+      new SuperTileBooster(
+        "superCol",
+        board,
+        views,
+        bus,
+        boosterService,
+        charges,
+        TileKind.SuperCol,
+      ),
+  },
+];

--- a/assets/scripts/core/boosters/BoosterSetup.ts
+++ b/assets/scripts/core/boosters/BoosterSetup.ts
@@ -1,11 +1,9 @@
 import { EventBus } from "../EventBus";
 import { BoosterService } from "./BoosterService";
-import { SuperTileBooster } from "./SuperTileBooster";
 import { Board } from "../board/Board";
-import { TileKind } from "../board/Tile";
 import TileView from "../../ui/views/TileView";
 import type { GameState } from "../game/GameStateMachine";
-import { TeleportBooster } from "./TeleportBooster";
+import { BoosterRegistry } from "./BoosterRegistry";
 
 export let boosterService: BoosterService | undefined;
 
@@ -20,40 +18,14 @@ export function initBoosterService(
   charges: Record<string, number>,
 ): void {
   boosterService = new BoosterService(EventBus, getState);
-  boosterService.register(
-    new TeleportBooster(board, EventBus, charges.teleport ?? 0),
-  );
-  boosterService.register(
-    new SuperTileBooster(
-      "bomb",
+  BoosterRegistry.forEach((def) => {
+    const boost = def.factory({
       board,
       views,
-      EventBus,
+      bus: EventBus,
       boosterService,
-      charges.bomb ?? 0,
-      TileKind.SuperBomb,
-    ),
-  );
-  boosterService.register(
-    new SuperTileBooster(
-      "superRow",
-      board,
-      views,
-      EventBus,
-      boosterService,
-      charges.superRow ?? 0,
-      TileKind.SuperRow,
-    ),
-  );
-  boosterService.register(
-    new SuperTileBooster(
-      "superCol",
-      board,
-      views,
-      EventBus,
-      boosterService,
-      charges.superCol ?? 0,
-      TileKind.SuperCol,
-    ),
-  );
+      charges: charges[def.id] ?? 0,
+    });
+    boosterService.register(boost);
+  });
 }


### PR DESCRIPTION
## Summary
- centralize booster definitions via BoosterRegistry
- auto register boosters through BoosterRegistry
- make booster UI and config derive from BoosterRegistry

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688e3f2cf5c48320b0e0d0826ae18fb4