### PR TITLE
refactor: dynamic booster limit config

### DIFF
--- a/__tests__/config/BoosterLimits.spec.ts
+++ b/__tests__/config/BoosterLimits.spec.ts
@@ -35,4 +35,22 @@ describe("loadBoosterLimits", () => {
       maxPerType: expected,
     });
   });
+
+  it("ignores unknown booster ids", () => {
+    (
+      globalThis as unknown as {
+        localStorage: { getItem: () => string | null };
+      }
+    ).localStorage = {
+      getItem: () =>
+        JSON.stringify({ maxPerType: { ghost: 7, bomb: 4 }, maxTypes: 5 }),
+    };
+    const expected = Object.fromEntries(
+      BoosterRegistry.map((b) => [b.id, b.id === "bomb" ? 4 : 10]),
+    );
+    expect(loadBoosterLimits()).toEqual({
+      maxTypes: 5,
+      maxPerType: expected,
+    });
+  });
 });

--- a/assets/scripts/config/ConfigLoader.ts
+++ b/assets/scripts/config/ConfigLoader.ts
@@ -69,19 +69,25 @@ export const DefaultBoosterLimits: BoosterLimitConfig = {
 /** Загружает настройки лимитов бустеров из localStorage. */
 export function loadBoosterLimits(): BoosterLimitConfig {
   const raw = localStorage.getItem("booster-limits.json");
-  if (!raw) return DefaultBoosterLimits;
-  try {
-    const parsed = JSON.parse(raw) as Partial<BoosterLimitConfig>;
-    const maxPerType = Object.assign(
-      {},
-      DefaultBoosterLimits.maxPerType,
-      parsed.maxPerType,
-    );
-    return {
-      maxTypes: parsed.maxTypes ?? DefaultBoosterLimits.maxTypes,
-      maxPerType,
-    };
-  } catch {
-    return DefaultBoosterLimits;
+  let parsed: Partial<BoosterLimitConfig> = {};
+
+  if (raw) {
+    try {
+      parsed = JSON.parse(raw) as Partial<BoosterLimitConfig>;
+    } catch {
+      parsed = {};
+    }
   }
+
+  const maxPerType: Record<string, number> = {};
+  BoosterRegistry.forEach(({ id }) => {
+    const stored = parsed.maxPerType?.[id];
+    maxPerType[id] =
+      typeof stored === "number" ? stored : DefaultBoosterLimits.maxPerType[id];
+  });
+
+  return {
+    maxTypes: parsed.maxTypes ?? DefaultBoosterLimits.maxTypes,
+    maxPerType,
+  };
 }


### PR DESCRIPTION
## Summary
- load booster limits by iterating BoosterRegistry and merging stored values with defaults
- ensure maxPerType uses dynamic Record<string, number>
- test ignoring unknown booster IDs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688e52fc81088320aba3dad6bd61deba