### PR TITLE
feat(ui): add booster panel controller

### DIFF
--- a/__tests__/config/BoosterLimits.spec.ts
+++ b/__tests__/config/BoosterLimits.spec.ts
@@ -1,11 +1,13 @@
 import {
   loadBoosterLimits,
   DefaultBoosterLimits,
+  clearConfigCache,
 } from "../../assets/scripts/config/ConfigLoader";
 import { BoosterRegistry } from "../../assets/scripts/core/boosters/BoosterRegistry";
 
 describe("loadBoosterLimits", () => {
   beforeEach(() => {
+    clearConfigCache();
     (
       globalThis as unknown as {
         localStorage: { getItem: () => string | null };

--- a/assets/scenes/GameScene.fire
+++ b/assets/scenes/GameScene.fire
@@ -78,13 +78,13 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 175
-      },
-      {
-        "__id__": 176
-      },
-      {
         "__id__": 177
+      },
+      {
+        "__id__": 178
+      },
+      {
+        "__id__": 179
       }
     ],
     "_prefab": null,
@@ -248,20 +248,14 @@
         "__id__": 8
       },
       {
-        "__id__": 81
+        "__id__": 83
       },
       {
-        "__id__": 84
+        "__id__": 86
       }
     ],
     "_active": true,
     "_components": [
-      {
-        "__id__": 168
-      },
-      {
-        "__id__": 169
-      },
       {
         "__id__": 170
       },
@@ -276,6 +270,12 @@
       },
       {
         "__id__": 174
+      },
+      {
+        "__id__": 175
+      },
+      {
+        "__id__": 176
       }
     ],
     "_prefab": null,
@@ -1602,9 +1602,13 @@
       }
     ],
     "_active": true,
-    "_components": [],
+    "_components": [
+      {
+        "__id__": 81
+      }
+    ],
     "_prefab": {
-      "__id__": 80
+      "__id__": 82
     },
     "_opacity": 255,
     "_color": {
@@ -1775,17 +1779,17 @@
         "__id__": 44
       },
       {
-        "__id__": 61
+        "__id__": 62
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 78
+        "__id__": 79
       }
     ],
     "_prefab": {
-      "__id__": 79
+      "__id__": 80
     },
     "_opacity": 255,
     "_color": {
@@ -1846,20 +1850,20 @@
         "__id__": 45
       },
       {
-        "__id__": 48
+        "__id__": 49
       },
       {
-        "__id__": 51
+        "__id__": 52
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 59
+        "__id__": 60
       }
     ],
     "_prefab": {
-      "__id__": 60
+      "__id__": 61
     },
     "_opacity": 255,
     "_color": {
@@ -1920,10 +1924,13 @@
     "_components": [
       {
         "__id__": 46
+      },
+      {
+        "__id__": 47
       }
     ],
     "_prefab": {
-      "__id__": 47
+      "__id__": 48
     },
     "_opacity": 255,
     "_color": {
@@ -2005,6 +2012,24 @@
     "_id": "50hxmlps5PDLT6ZkGxqcP5"
   },
   {
+    "__type__": "6f39cySoRhEu6uSaIiY0agr",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 45
+    },
+    "_enabled": true,
+    "highlightColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 235,
+      "b": 4,
+      "a": 255
+    },
+    "highlightOpacity": 255,
+    "_id": "edG0Y4jSlFvJsXbuMLQp5N"
+  },
+  {
     "__type__": "cc.PrefabInfo",
     "root": {
       "__id__": 44
@@ -2026,11 +2051,11 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 49
+        "__id__": 50
       }
     ],
     "_prefab": {
-      "__id__": 50
+      "__id__": 51
     },
     "_opacity": 255,
     "_color": {
@@ -2084,7 +2109,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 48
+      "__id__": 49
     },
     "_enabled": true,
     "_materials": [
@@ -2131,16 +2156,16 @@
     },
     "_children": [
       {
-        "__id__": 52
+        "__id__": 53
       },
       {
-        "__id__": 55
+        "__id__": 56
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 58
+      "__id__": 59
     },
     "_opacity": 255,
     "_color": {
@@ -2194,17 +2219,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 51
+      "__id__": 52
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 53
+        "__id__": 54
       }
     ],
     "_prefab": {
-      "__id__": 54
+      "__id__": 55
     },
     "_opacity": 255,
     "_color": {
@@ -2258,7 +2283,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 52
+      "__id__": 53
     },
     "_enabled": true,
     "_materials": [
@@ -2301,17 +2326,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 51
+      "__id__": 52
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 56
+        "__id__": 57
       }
     ],
     "_prefab": {
-      "__id__": 57
+      "__id__": 58
     },
     "_opacity": 255,
     "_color": {
@@ -2365,7 +2390,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 55
+      "__id__": 56
     },
     "_enabled": true,
     "_materials": [
@@ -2507,23 +2532,23 @@
     },
     "_children": [
       {
-        "__id__": 62
+        "__id__": 63
       },
       {
-        "__id__": 65
+        "__id__": 66
       },
       {
-        "__id__": 68
+        "__id__": 69
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 76
+        "__id__": 77
       }
     ],
     "_prefab": {
-      "__id__": 77
+      "__id__": 78
     },
     "_opacity": 255,
     "_color": {
@@ -2577,17 +2602,17 @@
     "_name": "BoosterSlotBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 61
+      "__id__": 62
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 63
+        "__id__": 64
       }
     ],
     "_prefab": {
-      "__id__": 64
+      "__id__": 65
     },
     "_opacity": 255,
     "_color": {
@@ -2641,7 +2666,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 62
+      "__id__": 63
     },
     "_enabled": true,
     "_materials": [
@@ -2671,7 +2696,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -2684,17 +2709,17 @@
     "_name": "BoosterIcon",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 61
+      "__id__": 62
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 66
+        "__id__": 67
       }
     ],
     "_prefab": {
-      "__id__": 67
+      "__id__": 68
     },
     "_opacity": 255,
     "_color": {
@@ -2748,7 +2773,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 65
+      "__id__": 66
     },
     "_enabled": true,
     "_materials": [
@@ -2778,7 +2803,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -2791,20 +2816,20 @@
     "_name": "BoosterCounter",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 61
+      "__id__": 62
     },
     "_children": [
       {
-        "__id__": 69
+        "__id__": 70
       },
       {
-        "__id__": 72
+        "__id__": 73
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 75
+      "__id__": 76
     },
     "_opacity": 255,
     "_color": {
@@ -2858,17 +2883,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 68
+      "__id__": 69
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 70
+        "__id__": 71
       }
     ],
     "_prefab": {
-      "__id__": 71
+      "__id__": 72
     },
     "_opacity": 255,
     "_color": {
@@ -2922,7 +2947,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 69
+      "__id__": 70
     },
     "_enabled": true,
     "_materials": [
@@ -2952,7 +2977,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -2965,17 +2990,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 68
+      "__id__": 69
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 73
+        "__id__": 74
       }
     ],
     "_prefab": {
-      "__id__": 74
+      "__id__": 75
     },
     "_opacity": 255,
     "_color": {
@@ -3029,7 +3054,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 72
+      "__id__": 73
     },
     "_enabled": true,
     "_materials": [
@@ -3062,7 +3087,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -3073,7 +3098,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -3086,7 +3111,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 61
+      "__id__": 62
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -3147,14 +3172,14 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 61
+      "__id__": 62
     },
     "_id": "73iXfqKB5JiJ0HpHWGBTtt"
   },
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 61
+      "__id__": 62
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -3206,6 +3231,19 @@
     "sync": false
   },
   {
+    "__type__": "f49acYCKaFI+ojlS5USq3xb",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 39
+    },
+    "_enabled": true,
+    "boosterList": {
+      "__id__": 43
+    },
+    "_id": "49yCQ1iSFK2qcTE5xSlukD"
+  },
+  {
     "__type__": "cc.PrefabInfo",
     "root": {
       "__id__": 39
@@ -3227,11 +3265,11 @@
     "_active": true,
     "_components": [
       {
-        "__id__": 82
+        "__id__": 84
       }
     ],
     "_prefab": {
-      "__id__": 83
+      "__id__": 85
     },
     "_opacity": 255,
     "_color": {
@@ -3285,7 +3323,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 81
+      "__id__": 83
     },
     "_enabled": true,
     "_materials": [
@@ -3386,7 +3424,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 81
+      "__id__": 83
     },
     "asset": {
       "__uuid__": "c6f7c67a-bac7-4d67-848a-4578d9c31995"
@@ -3403,9 +3441,6 @@
     },
     "_children": [
       {
-        "__id__": 85
-      },
-      {
         "__id__": 87
       },
       {
@@ -3415,16 +3450,19 @@
         "__id__": 91
       },
       {
-        "__id__": 161
+        "__id__": 93
+      },
+      {
+        "__id__": 163
       }
     ],
     "_active": false,
     "_components": [
       {
-        "__id__": 166
+        "__id__": 168
       },
       {
-        "__id__": 167
+        "__id__": 169
       }
     ],
     "_prefab": null,
@@ -3480,13 +3518,13 @@
     "_name": "GameNameLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 84
+      "__id__": 86
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 86
+        "__id__": 88
       }
     ],
     "_prefab": null,
@@ -3542,7 +3580,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 85
+      "__id__": 87
     },
     "_enabled": true,
     "_materials": [
@@ -3577,13 +3615,13 @@
     "_name": "SelectBoosterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 84
+      "__id__": 86
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 88
+        "__id__": 90
       }
     ],
     "_prefab": null,
@@ -3639,7 +3677,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 87
+      "__id__": 89
     },
     "_enabled": true,
     "_materials": [
@@ -3674,13 +3712,13 @@
     "_name": "BoosterSelectBackground",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 84
+      "__id__": 86
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 90
+        "__id__": 92
       }
     ],
     "_prefab": null,
@@ -3736,7 +3774,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 89
+      "__id__": 91
     },
     "_enabled": true,
     "_materials": [
@@ -3768,26 +3806,26 @@
     "_name": "BoosterSlotGrid",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 84
+      "__id__": 86
     },
     "_children": [
       {
-        "__id__": 92
+        "__id__": 94
       },
       {
-        "__id__": 109
+        "__id__": 111
       },
       {
-        "__id__": 126
+        "__id__": 128
       },
       {
-        "__id__": 143
+        "__id__": 145
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 160
+        "__id__": 162
       }
     ],
     "_prefab": null,
@@ -3843,27 +3881,27 @@
     "_name": "Slot",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 91
+      "__id__": 93
     },
     "_children": [
       {
-        "__id__": 93
+        "__id__": 95
       },
       {
-        "__id__": 96
+        "__id__": 98
       },
       {
-        "__id__": 99
+        "__id__": 101
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 107
+        "__id__": 109
       }
     ],
     "_prefab": {
-      "__id__": 108
+      "__id__": 110
     },
     "_opacity": 255,
     "_color": {
@@ -3917,17 +3955,17 @@
     "_name": "BoosterSlotBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 92
+      "__id__": 94
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 94
+        "__id__": 96
       }
     ],
     "_prefab": {
-      "__id__": 95
+      "__id__": 97
     },
     "_opacity": 255,
     "_color": {
@@ -3981,7 +4019,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 93
+      "__id__": 95
     },
     "_enabled": true,
     "_materials": [
@@ -4011,7 +4049,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4024,17 +4062,17 @@
     "_name": "BoosterIcon",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 92
+      "__id__": 94
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 97
+        "__id__": 99
       }
     ],
     "_prefab": {
-      "__id__": 98
+      "__id__": 100
     },
     "_opacity": 255,
     "_color": {
@@ -4088,7 +4126,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 96
+      "__id__": 98
     },
     "_enabled": true,
     "_materials": [
@@ -4118,7 +4156,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4131,20 +4169,20 @@
     "_name": "BoosterCounter",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 92
+      "__id__": 94
     },
     "_children": [
       {
-        "__id__": 100
+        "__id__": 102
       },
       {
-        "__id__": 103
+        "__id__": 105
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 106
+      "__id__": 108
     },
     "_opacity": 255,
     "_color": {
@@ -4198,17 +4236,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 99
+      "__id__": 101
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 101
+        "__id__": 103
       }
     ],
     "_prefab": {
-      "__id__": 102
+      "__id__": 104
     },
     "_opacity": 255,
     "_color": {
@@ -4262,7 +4300,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 100
+      "__id__": 102
     },
     "_enabled": true,
     "_materials": [
@@ -4292,7 +4330,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4305,17 +4343,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 99
+      "__id__": 101
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 104
+        "__id__": 106
       }
     ],
     "_prefab": {
-      "__id__": 105
+      "__id__": 107
     },
     "_opacity": 255,
     "_color": {
@@ -4369,7 +4407,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 103
+      "__id__": 105
     },
     "_enabled": true,
     "_materials": [
@@ -4402,7 +4440,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4413,7 +4451,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4426,7 +4464,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 92
+      "__id__": 94
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -4487,14 +4525,14 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 92
+      "__id__": 94
     },
     "_id": "48zqOCN6FDLraknuwrjsAS"
   },
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 92
+      "__id__": 94
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4507,27 +4545,27 @@
     "_name": "Slot",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 91
+      "__id__": 93
     },
     "_children": [
       {
-        "__id__": 110
+        "__id__": 112
       },
       {
-        "__id__": 113
+        "__id__": 115
       },
       {
-        "__id__": 116
+        "__id__": 118
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 124
+        "__id__": 126
       }
     ],
     "_prefab": {
-      "__id__": 125
+      "__id__": 127
     },
     "_opacity": 255,
     "_color": {
@@ -4581,17 +4619,17 @@
     "_name": "BoosterSlotBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 109
+      "__id__": 111
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 111
+        "__id__": 113
       }
     ],
     "_prefab": {
-      "__id__": 112
+      "__id__": 114
     },
     "_opacity": 255,
     "_color": {
@@ -4645,7 +4683,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 110
+      "__id__": 112
     },
     "_enabled": true,
     "_materials": [
@@ -4675,7 +4713,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4688,17 +4726,17 @@
     "_name": "BoosterIcon",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 109
+      "__id__": 111
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 114
+        "__id__": 116
       }
     ],
     "_prefab": {
-      "__id__": 115
+      "__id__": 117
     },
     "_opacity": 255,
     "_color": {
@@ -4752,7 +4790,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 113
+      "__id__": 115
     },
     "_enabled": true,
     "_materials": [
@@ -4782,7 +4820,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4795,20 +4833,20 @@
     "_name": "BoosterCounter",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 109
+      "__id__": 111
     },
     "_children": [
       {
-        "__id__": 117
+        "__id__": 119
       },
       {
-        "__id__": 120
+        "__id__": 122
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 123
+      "__id__": 125
     },
     "_opacity": 255,
     "_color": {
@@ -4862,17 +4900,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 116
+      "__id__": 118
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 118
+        "__id__": 120
       }
     ],
     "_prefab": {
-      "__id__": 119
+      "__id__": 121
     },
     "_opacity": 255,
     "_color": {
@@ -4926,7 +4964,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 117
+      "__id__": 119
     },
     "_enabled": true,
     "_materials": [
@@ -4956,7 +4994,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -4969,17 +5007,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 116
+      "__id__": 118
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 121
+        "__id__": 123
       }
     ],
     "_prefab": {
-      "__id__": 122
+      "__id__": 124
     },
     "_opacity": 255,
     "_color": {
@@ -5033,7 +5071,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 120
+      "__id__": 122
     },
     "_enabled": true,
     "_materials": [
@@ -5066,7 +5104,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5077,7 +5115,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5090,7 +5128,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 109
+      "__id__": 111
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -5151,14 +5189,14 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 109
+      "__id__": 111
     },
     "_id": "e2eF6EbkpOQbzRbq9Te1gL"
   },
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 109
+      "__id__": 111
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5171,27 +5209,27 @@
     "_name": "Slot",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 91
+      "__id__": 93
     },
     "_children": [
       {
-        "__id__": 127
+        "__id__": 129
       },
       {
-        "__id__": 130
+        "__id__": 132
       },
       {
-        "__id__": 133
+        "__id__": 135
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 141
+        "__id__": 143
       }
     ],
     "_prefab": {
-      "__id__": 142
+      "__id__": 144
     },
     "_opacity": 255,
     "_color": {
@@ -5245,17 +5283,17 @@
     "_name": "BoosterSlotBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 126
+      "__id__": 128
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 128
+        "__id__": 130
       }
     ],
     "_prefab": {
-      "__id__": 129
+      "__id__": 131
     },
     "_opacity": 255,
     "_color": {
@@ -5309,7 +5347,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 127
+      "__id__": 129
     },
     "_enabled": true,
     "_materials": [
@@ -5339,7 +5377,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5352,17 +5390,17 @@
     "_name": "BoosterIcon",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 126
+      "__id__": 128
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 131
+        "__id__": 133
       }
     ],
     "_prefab": {
-      "__id__": 132
+      "__id__": 134
     },
     "_opacity": 255,
     "_color": {
@@ -5416,7 +5454,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 130
+      "__id__": 132
     },
     "_enabled": true,
     "_materials": [
@@ -5446,7 +5484,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5459,20 +5497,20 @@
     "_name": "BoosterCounter",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 126
+      "__id__": 128
     },
     "_children": [
       {
-        "__id__": 134
+        "__id__": 136
       },
       {
-        "__id__": 137
+        "__id__": 139
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 140
+      "__id__": 142
     },
     "_opacity": 255,
     "_color": {
@@ -5526,17 +5564,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 133
+      "__id__": 135
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 135
+        "__id__": 137
       }
     ],
     "_prefab": {
-      "__id__": 136
+      "__id__": 138
     },
     "_opacity": 255,
     "_color": {
@@ -5590,7 +5628,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 134
+      "__id__": 136
     },
     "_enabled": true,
     "_materials": [
@@ -5620,7 +5658,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5633,17 +5671,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 133
+      "__id__": 135
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 138
+        "__id__": 140
       }
     ],
     "_prefab": {
-      "__id__": 139
+      "__id__": 141
     },
     "_opacity": 255,
     "_color": {
@@ -5697,7 +5735,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 137
+      "__id__": 139
     },
     "_enabled": true,
     "_materials": [
@@ -5730,7 +5768,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5741,7 +5779,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5754,7 +5792,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 126
+      "__id__": 128
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -5815,14 +5853,14 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 126
+      "__id__": 128
     },
     "_id": "724l/VfQFNeZ7msdcG2hd3"
   },
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 126
+      "__id__": 128
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -5835,27 +5873,27 @@
     "_name": "Slot",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 91
+      "__id__": 93
     },
     "_children": [
       {
-        "__id__": 144
+        "__id__": 146
       },
       {
-        "__id__": 147
+        "__id__": 149
       },
       {
-        "__id__": 150
+        "__id__": 152
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 158
+        "__id__": 160
       }
     ],
     "_prefab": {
-      "__id__": 159
+      "__id__": 161
     },
     "_opacity": 255,
     "_color": {
@@ -5909,17 +5947,17 @@
     "_name": "BoosterSlotBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 143
+      "__id__": 145
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 145
+        "__id__": 147
       }
     ],
     "_prefab": {
-      "__id__": 146
+      "__id__": 148
     },
     "_opacity": 255,
     "_color": {
@@ -5973,7 +6011,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 144
+      "__id__": 146
     },
     "_enabled": true,
     "_materials": [
@@ -6003,7 +6041,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6016,17 +6054,17 @@
     "_name": "BoosterIcon",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 143
+      "__id__": 145
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 148
+        "__id__": 150
       }
     ],
     "_prefab": {
-      "__id__": 149
+      "__id__": 151
     },
     "_opacity": 255,
     "_color": {
@@ -6080,7 +6118,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 147
+      "__id__": 149
     },
     "_enabled": true,
     "_materials": [
@@ -6110,7 +6148,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6123,20 +6161,20 @@
     "_name": "BoosterCounter",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 143
+      "__id__": 145
     },
     "_children": [
       {
-        "__id__": 151
+        "__id__": 153
       },
       {
-        "__id__": 154
+        "__id__": 156
       }
     ],
     "_active": true,
     "_components": [],
     "_prefab": {
-      "__id__": 157
+      "__id__": 159
     },
     "_opacity": 255,
     "_color": {
@@ -6190,17 +6228,17 @@
     "_name": "BoosterCounterBg",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 150
+      "__id__": 152
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 152
+        "__id__": 154
       }
     ],
     "_prefab": {
-      "__id__": 153
+      "__id__": 155
     },
     "_opacity": 255,
     "_color": {
@@ -6254,7 +6292,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 151
+      "__id__": 153
     },
     "_enabled": true,
     "_materials": [
@@ -6284,7 +6322,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6297,17 +6335,17 @@
     "_name": "CounterLabel",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 150
+      "__id__": 152
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 155
+        "__id__": 157
       }
     ],
     "_prefab": {
-      "__id__": 156
+      "__id__": 158
     },
     "_opacity": 255,
     "_color": {
@@ -6361,7 +6399,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 154
+      "__id__": 156
     },
     "_enabled": true,
     "_materials": [
@@ -6394,7 +6432,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6405,7 +6443,7 @@
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6418,7 +6456,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 143
+      "__id__": 145
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -6479,14 +6517,14 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 143
+      "__id__": 145
     },
     "_id": "cfy61oDrVM6LOFnSwGcGmg"
   },
   {
     "__type__": "cc.PrefabInfo",
     "root": {
-      "__id__": 143
+      "__id__": 145
     },
     "asset": {
       "__uuid__": "b967e88d-4cde-4c9d-b2e7-ff8a2c8c882f"
@@ -6499,7 +6537,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 91
+      "__id__": 93
     },
     "_enabled": true,
     "_layoutSize": {
@@ -6531,20 +6569,20 @@
     "_name": "PlayButton",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 84
+      "__id__": 86
     },
     "_children": [
       {
-        "__id__": 162
+        "__id__": 164
       }
     ],
     "_active": true,
     "_components": [
       {
-        "__id__": 164
+        "__id__": 166
       },
       {
-        "__id__": 165
+        "__id__": 167
       }
     ],
     "_prefab": null,
@@ -6600,13 +6638,13 @@
     "_name": "Label",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 161
+      "__id__": 163
     },
     "_children": [],
     "_active": true,
     "_components": [
       {
-        "__id__": 163
+        "__id__": 165
       }
     ],
     "_prefab": null,
@@ -6662,7 +6700,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 162
+      "__id__": 164
     },
     "_enabled": true,
     "_materials": [
@@ -6697,7 +6735,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 161
+      "__id__": 163
     },
     "_enabled": true,
     "_materials": [
@@ -6729,7 +6767,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 161
+      "__id__": 163
     },
     "_enabled": true,
     "_normalMaterial": null,
@@ -6790,7 +6828,7 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 161
+      "__id__": 163
     },
     "_id": "90PZBa8SNHi5Ecv34dq5Xf"
   },
@@ -6799,34 +6837,34 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 84
+      "__id__": 86
     },
     "_enabled": true,
     "gameNameLabel": {
-      "__id__": 85
-    },
-    "selectBoosterLabel": {
       "__id__": 87
     },
-    "boosterSelectBackground": {
+    "selectBoosterLabel": {
       "__id__": 89
+    },
+    "boosterSelectBackground": {
+      "__id__": 91
     },
     "boosterSlots": [
       {
-        "__id__": 92
+        "__id__": 94
       },
       {
-        "__id__": 109
+        "__id__": 111
       },
       {
-        "__id__": 126
+        "__id__": 128
       },
       {
-        "__id__": 143
+        "__id__": 145
       }
     ],
     "playButton": {
-      "__id__": 161
+      "__id__": 163
     },
     "labelDelay": 0.2,
     "backgroundDelay": 0.4,
@@ -6842,7 +6880,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 84
+      "__id__": 86
     },
     "_enabled": true,
     "_id": "7fTBrquwJPoJD71LMUiPCr"
@@ -6948,7 +6986,7 @@
     },
     "_enabled": true,
     "boosterSelectPopup": {
-      "__id__": 84
+      "__id__": 86
     },
     "gameBoard": {
       "__id__": 8

--- a/assets/scripts/config/ConfigLoader.ts
+++ b/assets/scripts/config/ConfigLoader.ts
@@ -118,5 +118,30 @@ export const DefaultBoosterLimits: BoosterLimitConfig = {
 /** Загружает настройки лимитов бустеров. */
 export function loadBoosterLimits(): BoosterLimitConfig {
   const config = loadGameConfig();
-  return config.boosterLimits;
+  const base = { ...config.boosterLimits };
+  const storage = (
+    globalThis as unknown as {
+      localStorage?: { getItem: (key: string) => string | null };
+    }
+  ).localStorage;
+  if (!storage) return base;
+
+  try {
+    const raw = storage.getItem("boosterLimits");
+    if (!raw) return base;
+    const data = JSON.parse(raw) as Partial<BoosterLimitConfig>;
+    if (typeof data.maxTypes === "number") {
+      base.maxTypes = data.maxTypes;
+    }
+    if (data.maxPerType) {
+      Object.entries(data.maxPerType).forEach(([id, val]) => {
+        if (base.maxPerType[id] !== undefined) {
+          base.maxPerType[id] = val as number;
+        }
+      });
+    }
+    return base;
+  } catch {
+    return base;
+  }
 }

--- a/assets/scripts/ui/controllers/BoosterPanelController.ts
+++ b/assets/scripts/ui/controllers/BoosterPanelController.ts
@@ -1,0 +1,182 @@
+import { EventBus } from "../../core/EventBus";
+import { EventNames } from "../../core/events/EventNames";
+import { boosterService } from "../../core/boosters/BoosterSetup";
+import SpriteHighlight from "../utils/SpriteHighlight";
+
+const { ccclass, property } = cc._decorator;
+
+interface BoosterSlot {
+  node: cc.Node;
+  button: cc.Button | null;
+  icon: cc.Sprite | null;
+  counterLabel: cc.Label | null;
+  highlight: SpriteHighlight | null;
+  boosterId: string;
+  charges: number;
+  isActive: boolean;
+}
+
+@ccclass()
+export default class BoosterPanelController extends cc.Component {
+  @property(cc.Node)
+  boosterList: cc.Node = null;
+
+  private selectedBoosters: Record<string, number> = {};
+  private boosterSlots: BoosterSlot[] = [];
+
+  start(): void {
+    this.initializeSlots();
+    this.setupEventListeners();
+  }
+
+  private initializeSlots(): void {
+    if (!this.boosterList) return;
+    this.boosterSlots = [];
+    this.boosterList.children.forEach((child: cc.Node) => {
+      const button = child.getComponent(cc.Button);
+      const icon =
+        child.getChildByName("Icon")?.getComponent(cc.Sprite) || null;
+      const counterLabel =
+        child.getChildByName("CounterLabel")?.getComponent(cc.Label) || null;
+      const slot: BoosterSlot = {
+        node: child,
+        button,
+        icon,
+        counterLabel,
+        highlight: null,
+        boosterId: "",
+        charges: 0,
+        isActive: false,
+      };
+      this.addHighlightToSlot(slot);
+      this.setupSlotClickHandler(slot);
+      child.active = false;
+      this.boosterSlots.push(slot);
+    });
+  }
+
+  private setupEventListeners(): void {
+    EventBus.on(EventNames.BoostersSelected, this.onBoostersSelected, this);
+    EventBus.on(EventNames.BoosterConsumed, this.onBoosterConsumed, this);
+    EventBus.on(EventNames.BoosterCancelled, this.onBoosterCancelled, this);
+  }
+
+  private onBoostersSelected(charges: Record<string, number>): void {
+    this.selectedBoosters = charges;
+    this.populateBoosterSlots();
+  }
+
+  private populateBoosterSlots(): void {
+    const activeBoosters = Object.entries(this.selectedBoosters).filter(
+      ([, count]) => count > 0,
+    );
+    this.boosterSlots.forEach((slot, index) => {
+      const boosterData = activeBoosters[index];
+      if (boosterData) {
+        const [boosterId, charges] = boosterData;
+        this.setupBoosterSlot(slot, boosterId, charges);
+      } else {
+        this.hideBoosterSlot(slot);
+      }
+    });
+  }
+
+  private setupBoosterSlot(
+    slot: BoosterSlot,
+    boosterId: string,
+    charges: number,
+  ): void {
+    slot.boosterId = boosterId;
+    slot.charges = charges;
+    slot.isActive = false;
+
+    this.setBoosterIcon(slot, boosterId);
+
+    if (slot.counterLabel) {
+      slot.counterLabel.string = String(charges);
+    }
+
+    slot.node.active = true;
+
+    this.setupSlotClickHandler(slot);
+  }
+
+  private setBoosterIcon(slot: BoosterSlot, boosterId: string): void {
+    if (!slot.icon) return;
+    const path = `ui/images/boosters/icon_booster_${boosterId}`;
+    cc.resources.load(path, cc.SpriteFrame, (err, spriteFrame) => {
+      if (!err && spriteFrame && slot.icon) {
+        slot.icon.spriteFrame = spriteFrame as cc.SpriteFrame;
+      }
+    });
+  }
+
+  private addHighlightToSlot(slot: BoosterSlot): void {
+    const highlight = slot.node.addComponent(SpriteHighlight);
+    highlight.highlightColor = cc.Color.YELLOW;
+    highlight.highlightOpacity = 200;
+    slot.highlight = highlight;
+  }
+
+  private setupSlotClickHandler(slot: BoosterSlot): void {
+    if (!slot.button) return;
+    slot.button.node.off(cc.Node.EventType.TOUCH_END);
+    slot.button.node.on(cc.Node.EventType.TOUCH_END, () => {
+      this.handleSlotClick(slot);
+    });
+  }
+
+  private handleSlotClick(clickedSlot: BoosterSlot): void {
+    if (!clickedSlot.boosterId) return;
+    if (clickedSlot.isActive) {
+      this.clearActiveSlot();
+      boosterService?.cancel();
+      return;
+    }
+    this.setActiveSlot(clickedSlot);
+  }
+
+  private setActiveSlot(slot: BoosterSlot): void {
+    this.clearActiveSlot();
+    slot.isActive = true;
+    slot.highlight?.setHighlight();
+    boosterService?.activate(slot.boosterId);
+  }
+
+  private clearActiveSlot(): void {
+    const activeSlot = this.boosterSlots.find((s) => s.isActive);
+    if (activeSlot) {
+      activeSlot.isActive = false;
+      activeSlot.highlight?.clearHighlight();
+    }
+  }
+
+  private onBoosterConsumed(boosterId: string): void {
+    const slot = this.boosterSlots.find((s) => s.boosterId === boosterId);
+    if (slot) {
+      slot.charges = boosterService?.getCharges(boosterId) ?? 0;
+      if (slot.counterLabel) {
+        slot.counterLabel.string = String(slot.charges);
+      }
+      if (slot.charges <= 0) {
+        this.hideBoosterSlot(slot);
+      }
+    }
+  }
+
+  private onBoosterCancelled(): void {
+    this.clearActiveSlot();
+  }
+
+  private hideBoosterSlot(slot: BoosterSlot): void {
+    slot.node.active = false;
+    slot.isActive = false;
+    slot.highlight?.clearHighlight();
+  }
+
+  onDestroy(): void {
+    EventBus.off(EventNames.BoostersSelected, this.onBoostersSelected, this);
+    EventBus.off(EventNames.BoosterConsumed, this.onBoosterConsumed, this);
+    EventBus.off(EventNames.BoosterCancelled, this.onBoosterCancelled, this);
+  }
+}

--- a/assets/scripts/ui/controllers/BoosterPanelController.ts.meta
+++ b/assets/scripts/ui/controllers/BoosterPanelController.ts.meta
@@ -1,0 +1,10 @@
+{
+  "ver": "1.1.0",
+  "uuid": "f49ac602-29a1-48fa-88e5-4b9512ab7c5b",
+  "importer": "typescript",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}


### PR DESCRIPTION
## Summary
- add `BoosterPanelController` to populate and manage booster slots with highlight and activation logic
- allow `loadBoosterLimits` to merge localStorage overrides
- reset config cache in booster limit tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688e7cafd6b083208d5596363e73341f