### PR TITLE
feat: cache booster selections across sessions

### DIFF
--- a/assets/scripts/config/ConfigLoader.ts
+++ b/assets/scripts/config/ConfigLoader.ts
@@ -144,8 +144,12 @@ export function loadBoosterLimits(): BoosterLimitConfig {
 
   // Пытаемся загрузить из localStorage, если доступен
   try {
-    if (typeof window !== "undefined" && window.localStorage) {
-      const raw = window.localStorage.getItem("boosterLimits");
+    const storage: Partial<Storage> | undefined =
+      (typeof window !== "undefined" && window.localStorage) ||
+      (globalThis as unknown as { localStorage?: Partial<Storage> })
+        .localStorage;
+    if (storage && typeof storage.getItem === "function") {
+      const raw = storage.getItem("boosterLimits");
       if (raw) {
         const data = JSON.parse(raw) as Partial<BoosterLimitConfig>;
         if (typeof data.maxTypes === "number") {

--- a/assets/scripts/ui/controllers/BoosterPanelController.ts
+++ b/assets/scripts/ui/controllers/BoosterPanelController.ts
@@ -3,6 +3,7 @@ import { EventNames } from "../../core/events/EventNames";
 import { boosterService } from "../../core/boosters/BoosterSetup";
 import { BoosterRegistry } from "../../core/boosters/BoosterRegistry";
 import SpriteHighlight from "../utils/SpriteHighlight";
+import { boosterSelectionService } from "../services/BoosterSelectionService";
 
 const { ccclass, property } = cc._decorator;
 
@@ -28,6 +29,10 @@ export default class BoosterPanelController extends cc.Component {
   start(): void {
     this.initializeSlots();
     this.setupEventListeners();
+    const charges = boosterSelectionService.getConfirmedCharges();
+    if (Object.keys(charges).length > 0) {
+      this.onBoostersSelected(charges);
+    }
   }
 
   private initializeSlots(): void {

--- a/assets/scripts/ui/controllers/BoosterSelectPopup.ts
+++ b/assets/scripts/ui/controllers/BoosterSelectPopup.ts
@@ -32,6 +32,7 @@ export default class BoosterSelectPopup extends cc.Component {
       BoosterSelectAnimationController,
     );
     boosterSelectionService.reset();
+    boosterSelectionService.confirm();
     this.createSlots();
   }
 

--- a/assets/scripts/ui/services/BoosterSelectionService.ts
+++ b/assets/scripts/ui/services/BoosterSelectionService.ts
@@ -22,6 +22,7 @@ export class BoosterSelectionService {
 
   private limits: BoosterLimitConfig;
   private selected: string[] = [];
+  private confirmedCharges: Record<string, number> = {};
 
   private constructor() {
     this.limits = loadBoosterLimits();
@@ -57,11 +58,17 @@ export class BoosterSelectionService {
   confirm(): void {
     const charges: Record<string, number> = {};
     this.selected.forEach((id) => (charges[id] = 1));
+    this.confirmedCharges = charges;
     EventBus.emit(EventNames.BoostersSelected, charges);
   }
 
   reset(): void {
     this.selected = [];
+    this.confirmedCharges = {};
+  }
+
+  getConfirmedCharges(): Record<string, number> {
+    return { ...this.confirmedCharges };
   }
 }
 


### PR DESCRIPTION
## Summary
- cache selected boosters and expose confirmed charges
- restore cached boosters when panel starts
- reset cached boosters when selection popup loads
- ensure booster limits loader reads from global storage in tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688e9cd04dac832091078bff010ebc32