### PR TITLE
feat: add booster charges information

### DIFF
--- a/__tests__/ui/BoosterSelectionService.spec.ts
+++ b/__tests__/ui/BoosterSelectionService.spec.ts
@@ -1,0 +1,21 @@
+import { boosterSelectionService } from "../../assets/scripts/ui/services/BoosterSelectionService";
+import { BoosterRegistry } from "../../assets/scripts/core/boosters/BoosterRegistry";
+import { EventBus } from "../../assets/scripts/core/EventBus";
+
+describe("BoosterSelectionService", () => {
+  beforeEach(() => {
+    boosterSelectionService.reset();
+    EventBus.clear();
+  });
+
+  it("assigns max charges (10) for each selected booster", () => {
+    const [first, second] = BoosterRegistry;
+    boosterSelectionService.toggle(first.id);
+    boosterSelectionService.toggle(second.id);
+    boosterSelectionService.confirm();
+    expect(boosterSelectionService.getConfirmedCharges()).toEqual({
+      [first.id]: 10,
+      [second.id]: 10,
+    });
+  });
+});

--- a/assets/scripts/ui/services/BoosterSelectionService.ts
+++ b/assets/scripts/ui/services/BoosterSelectionService.ts
@@ -53,11 +53,15 @@ export class BoosterSelectionService {
 
   /**
    * Emits event with selected boosters and their charges.
-   * Currently each selected booster starts with one charge.
+   * Each selected booster starts with the maximum amount allowed by config
+   * (defaults to 10).
    */
   confirm(): void {
     const charges: Record<string, number> = {};
-    this.selected.forEach((id) => (charges[id] = 1));
+    this.selected.forEach((id) => {
+      const max = this.limits.maxPerType[id] ?? 10;
+      charges[id] = max;
+    });
     this.confirmedCharges = charges;
     EventBus.emit(EventNames.BoostersSelected, charges);
   }


### PR DESCRIPTION
## Summary
- use config max per booster to assign initial charges (10 each)
- add test verifying booster selection yields 10 charges per booster

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688ea39f142883208949dd35ccb4da57