### PR TITLE
[J-2-audit] Audit and fix Teleport booster logic (two-tap swap, cancellation, charge consumption, animation & event consistency)

### DIFF
--- a/__tests__/core/boosters/TeleportBooster.spec.ts
+++ b/__tests__/core/boosters/TeleportBooster.spec.ts
@@ -29,8 +29,8 @@ const cfg2x2: BoardConfig = {
   superThreshold: 3,
 };
 
-// Swap происходит и заряд тратится, если после обмена есть ходы
-it("consumes charge on successful swap", async () => {
+// Swap выполняется всегда и заряд тратится
+it("swaps tiles and consumes charge", async () => {
   const bus = new InfrastructureEventBus();
   const emitSpy = jest.spyOn(bus, "emit");
   const board = new Board(cfg2x2, [
@@ -64,9 +64,8 @@ it("consumes charge on successful swap", async () => {
   expect(board.colorAt(new cc.Vec2(1, 1))).toBe("blue");
 });
 
-// Когда после обмена нет ходов, заряд не тратится, а событие SwapCancelled
-// уведомляет о возврате
-it("cancels swap when no moves available", async () => {
+// Даже если после обмена нет возможных ходов, swap применяется
+it("still swaps when no further moves", async () => {
   const bus = new InfrastructureEventBus();
   const board = new Board(
     {
@@ -81,17 +80,19 @@ it("cancels swap when no moves available", async () => {
   );
   const booster = new TeleportBooster(board, bus, 1);
   const events: string[] = [];
-  bus.on(EventNames.SwapCancelled, () => events.push(EventNames.SwapCancelled));
+  bus.on(EventNames.BoosterConsumed, () =>
+    events.push(EventNames.BoosterConsumed),
+  );
 
   booster.start();
   bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
   bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
   await new Promise((r) => setImmediate(r));
 
-  expect(booster.charges).toBe(1);
-  expect(events).toEqual([EventNames.SwapCancelled]);
-  expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
-  expect(board.colorAt(new cc.Vec2(1, 0))).toBe("blue");
+  expect(booster.charges).toBe(0);
+  expect(events).toEqual([EventNames.BoosterConsumed]);
+  expect(board.colorAt(new cc.Vec2(0, 0))).toBe("blue");
+  expect(board.colorAt(new cc.Vec2(1, 0))).toBe("red");
 });
 
 // Второй тап по тому же тайлу отменяет выбор
@@ -146,4 +147,47 @@ it("cancels when tapping outside after first selection", () => {
   expect(booster.charges).toBe(1);
   expect(seq).toEqual(["select-first", EventNames.BoosterCancelled]);
   expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterCancelled);
+});
+
+// Попытка активации без зарядов ничего не делает
+it("ignores activation with zero charges", () => {
+  const bus = new InfrastructureEventBus();
+  const emitSpy = jest.spyOn(bus, "emit");
+  const board = new Board(cfg2x2, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+    [TileFactory.createNormal("blue"), TileFactory.createNormal("red")],
+  ]);
+  const booster = new TeleportBooster(board, bus, 0);
+
+  booster.start();
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
+
+  expect(emitSpy).toHaveBeenCalledWith(EventNames.BoosterCancelled);
+  expect(board.colorAt(new cc.Vec2(0, 0))).toBe("red");
+  expect(booster.charges).toBe(0);
+});
+
+// Повторные тапы после выбора второго тайла игнорируются
+it("ignores extra taps while swap is in progress", async () => {
+  const bus = new InfrastructureEventBus();
+  const board = new Board(cfg2x2, [
+    [TileFactory.createNormal("red"), TileFactory.createNormal("blue")],
+    [TileFactory.createNormal("blue"), TileFactory.createNormal("red")],
+  ]);
+  const booster = new TeleportBooster(board, bus, 2);
+  const seq: string[] = [];
+  bus.on(EventNames.SwapDone, () => seq.push(EventNames.SwapDone));
+  bus.on(EventNames.BoosterConsumed, () =>
+    seq.push(EventNames.BoosterConsumed),
+  );
+
+  booster.start();
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 0));
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(1, 0));
+  // extra taps should be ignored until reactivation
+  bus.emit(EventNames.GroupSelected, new cc.Vec2(0, 1));
+  await new Promise((r) => setImmediate(r));
+
+  expect(seq).toEqual([EventNames.SwapDone, EventNames.BoosterConsumed]);
+  expect(booster.charges).toBe(1);
 });


### PR DESCRIPTION
## Summary
- always apply teleport swaps and spend charges by default
- support optional requireMove flag and guard activation with no charges
- cover teleport interactions with extensive tests

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_688efe2b1bc88320a06a5b5eba0d9c2c