### PR TITLE
fix: sync booster tile view references

### DIFF
--- a/__tests__/core/boosters/SuperTileBooster.spec.ts
+++ b/__tests__/core/boosters/SuperTileBooster.spec.ts
@@ -23,10 +23,11 @@ describe("SuperTileBooster", () => {
     const board = new Board(cfg, [[TileFactory.createNormal("red")]]);
     const view = { apply: jest.fn() } as unknown as TileView;
     const views: TileView[][] = [[view]];
+    const getView = (p: cc.Vec2) => views[p.y]?.[p.x];
     const booster = new SuperTileBooster(
       "bomb",
       board,
-      views,
+      getView,
       bus,
       svc,
       1,

--- a/assets/scripts/GameScene.ts
+++ b/assets/scripts/GameScene.ts
@@ -45,7 +45,7 @@ export default class GameScene extends cc.Component {
       (charges: Record<string, number>) => {
         initBoosterService(
           board,
-          boardCtrl.tileViews,
+          () => boardCtrl.tileViews,
           () => currentState,
           charges,
         );

--- a/assets/scripts/core/boosters/BoosterRegistry.ts
+++ b/assets/scripts/core/boosters/BoosterRegistry.ts
@@ -9,7 +9,7 @@ import { TileKind } from "../board/Tile";
 
 export interface BoosterFactoryParams {
   board: Board;
-  views: TileView[][];
+  getView: (p: cc.Vec2) => TileView | undefined;
   bus: InfrastructureEventBus;
   boosterService: BoosterService;
   charges: number;
@@ -32,11 +32,11 @@ export const BoosterRegistry: BoosterDefinition[] = [
   {
     id: "bomb",
     icon: "images/boosters/icon_booster_bomb",
-    factory: ({ board, views, bus, boosterService, charges }) =>
+    factory: ({ board, getView, bus, boosterService, charges }) =>
       new SuperTileBooster(
         "bomb",
         board,
-        views,
+        getView,
         bus,
         boosterService,
         charges,
@@ -46,11 +46,11 @@ export const BoosterRegistry: BoosterDefinition[] = [
   {
     id: "superRow",
     icon: "images/boosters/icon_booster_superRow",
-    factory: ({ board, views, bus, boosterService, charges }) =>
+    factory: ({ board, getView, bus, boosterService, charges }) =>
       new SuperTileBooster(
         "superRow",
         board,
-        views,
+        getView,
         bus,
         boosterService,
         charges,
@@ -60,11 +60,11 @@ export const BoosterRegistry: BoosterDefinition[] = [
   {
     id: "superCol",
     icon: "images/boosters/icon_booster_superCol",
-    factory: ({ board, views, bus, boosterService, charges }) =>
+    factory: ({ board, getView, bus, boosterService, charges }) =>
       new SuperTileBooster(
         "superCol",
         board,
-        views,
+        getView,
         bus,
         boosterService,
         charges,

--- a/assets/scripts/core/boosters/BoosterSetup.ts
+++ b/assets/scripts/core/boosters/BoosterSetup.ts
@@ -13,15 +13,19 @@ export let boosterService: BoosterService | undefined;
  */
 export function initBoosterService(
   board: Board,
-  views: TileView[][],
+  viewProvider: () => TileView[][],
   getState: () => GameState,
   charges: Record<string, number>,
 ): void {
   boosterService = new BoosterService(EventBus, getState);
+  const getView = (p: cc.Vec2): TileView | undefined => {
+    const views = viewProvider();
+    return views[p.y]?.[p.x];
+  };
   BoosterRegistry.forEach((def) => {
     const boost = def.factory({
       board,
-      views,
+      getView,
       bus: EventBus,
       boosterService,
       charges: charges[def.id] ?? 0,

--- a/assets/scripts/core/boosters/SuperTileBooster.ts
+++ b/assets/scripts/core/boosters/SuperTileBooster.ts
@@ -19,7 +19,7 @@ export class SuperTileBooster implements Booster {
   constructor(
     id: string,
     private board: Board,
-    private views: TileView[][],
+    private getView: (p: cc.Vec2) => TileView | undefined,
     private bus: InfrastructureEventBus,
     private svc: BoosterService,
     charges: number,
@@ -46,7 +46,7 @@ export class SuperTileBooster implements Booster {
       this.svc.consume(this.id);
       const superTile: Tile = { ...tile, kind: this.kind };
       this.board.setTile(p, superTile);
-      const view = this.views[p.y]?.[p.x];
+      const view = this.getView(p);
       view?.apply(superTile);
       this.bus.emit(EventNames.SuperTilePlaced, {
         kind: this.kind,

--- a/assets/scripts/ui/views/TileView.ts
+++ b/assets/scripts/ui/views/TileView.ts
@@ -20,7 +20,7 @@ export default class TileView extends cc.Component {
 
   /** Префабы супер‑тайлов по индексу {@link SuperKind}. */
   @property([cc.Prefab])
-  superVariants: cc.Prefab[] = [];
+  superVariants: cc.Prefab[] | null = null;
 
   /** Текущий визуальный узел, размещённый в visualRoot. */
   private currentVisual: cc.Node | null = null;
@@ -68,7 +68,8 @@ export default class TileView extends cc.Component {
       const idx = this.colorIndex(tile.color);
       prefab = this.normalVariants[idx];
     } else {
-      prefab = this.superVariants[tile.kind];
+      const variants = this.superVariants || [];
+      prefab = variants[tile.kind];
     }
     if (!prefab) return;
 


### PR DESCRIPTION
## Summary
- fetch TileView dynamically when placing super tiles to avoid stale references
- guard TileView super variants to prevent null prefab crashes

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f230299d08320bfb121e67eb89e8d