### PR TITLE
fix: refresh booster panel on restart

### DIFF
--- a/assets/scripts/ui/controllers/BoosterPanelController.ts
+++ b/assets/scripts/ui/controllers/BoosterPanelController.ts
@@ -110,6 +110,8 @@ export default class BoosterPanelController extends cc.Component {
   private setupEventListeners(): void {
     EventBus.on(EventNames.BoosterConsumed, this.onBoosterConsumed, this);
     EventBus.on(EventNames.BoosterCancelled, this.onBoosterCancelled, this);
+    EventBus.on(EventNames.BoostersSelected, this.onBoostersSelected, this);
+    EventBus.on(EventNames.GameRestart, this.onGameRestart, this);
   }
 
   // Метод setupBoosterSlot больше не нужен - бустеры настраиваются при инициализации
@@ -204,6 +206,16 @@ export default class BoosterPanelController extends cc.Component {
     this.clearActiveSlot();
   }
 
+  private onBoostersSelected(charges: Record<string, number>): void {
+    this.createSlots(charges);
+  }
+
+  private onGameRestart(): void {
+    boosterService?.cancel();
+    this.clearActiveSlot();
+    this.createSlots({});
+  }
+
   private hideBoosterSlot(slot: BoosterSlot): void {
     slot.node.active = false;
     slot.isActive = false;
@@ -214,5 +226,7 @@ export default class BoosterPanelController extends cc.Component {
   onDestroy(): void {
     EventBus.off(EventNames.BoosterConsumed, this.onBoosterConsumed, this);
     EventBus.off(EventNames.BoosterCancelled, this.onBoosterCancelled, this);
+    EventBus.off(EventNames.BoostersSelected, this.onBoostersSelected, this);
+    EventBus.off(EventNames.GameRestart, this.onGameRestart, this);
   }
 }


### PR DESCRIPTION
## Summary
- rebuild booster panel when boosters are reselected
- clear active booster state on game restart

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688f555e669c83208f72f4207c32b48d