### PR TITLE
[K-1a] Set up GitHub Pages automation (Codex-handled portion)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,32 @@
+# Deploy prebuilt web assets to GitHub Pages
+name: Deploy # Human-friendly name for the workflow
+
+on:
+  push:
+    branches:
+      - main # Trigger only when committing to main branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest # Use a Linux runner
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4 # Fetch repository contents
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4 # Provide Node for optional build steps
+        with:
+          node-version: 20 # Utilize Node 20 LTS
+
+      - name: Prepare deployment folder
+        run: |
+          mkdir -p deploy # Create directory for deployment artifacts
+          cp -r build/web/* deploy/ # Copy pre-built web files
+
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4 # Push files to gh-pages branch
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Authentication token
+          publish_branch: gh-pages # Pages branch
+          publish_dir: ./deploy # Directory to publish
+          force_orphan: true # Create orphan branch for clean history

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,10 @@ local/
 # Temporary build data
 temp/
 # Final build output
-build/
+build/               # ignore all build outputs
+!build/web/          # allow tracking of the web build directory itself
+build/web/**         # ignore generated files within the web build
+!build/web/.gitkeep  # keep placeholder so the directory exists in git
 # Editor log files
 logs/
 # Temporary meta files created by the editor

--- a/build/web/.gitkeep
+++ b/build/web/.gitkeep
@@ -1,0 +1,1 @@
+# Ensures git keeps the build/web directory for deployment artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/seedrandom": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
+        "cocos-cli": "^0.1.25",
         "eslint": "^8.57.1",
         "husky": "^9.1.7",
         "jest": "^30.0.5",
@@ -3041,6 +3042,23 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/cocos-cli": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/cocos-cli/-/cocos-cli-0.1.25.tgz",
+      "integrity": "sha512-LAmiwiTg7KDIDd7rkyJkoijTd+RHFTx6KW1zXeTb05qoasvs33WJJV6Eu1S+1GH9sdNYNqGf/o1UVGbpUkEz2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "*",
+        "pngjs": "*",
+        "shelljs": "*",
+        "yargs": "*",
+        "zhandlebars": "*"
+      },
+      "bin": {
+        "cocoscli": "bin/cocoscli.js"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -4209,6 +4227,28 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -5948,6 +5988,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6307,6 +6354,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6822,6 +6879,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/signal-exit": {
@@ -7476,6 +7547,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -7627,6 +7712,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.0",
@@ -7879,6 +7971,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zhandlebars": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/zhandlebars/-/zhandlebars-0.1.8.tgz",
+      "integrity": "sha512-aE3h+NQpIKRX6PuW3jdTOkMs1eMBheA/nAH3UAqVopJOg2eN7kwgVB85qEZcseW9+4wFAkZM1eAu0GtnZ2vahA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "*",
+        "handlebars": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
     "test": "jest --runInBand",
     "lint": "eslint --config .eslintrc.cjs \"**/*.ts\"",
     "typecheck": "tsc --noEmit",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build:web": "cocos-cli build --platform web-mobile --output build/web # build web version into build/web",
+    "postinstall": "npx cocos-cli --version # confirm cocos CLI is installed"
   },
+  "// build:web script": "Generates the web-mobile build into build/web for GitHub Pages",
+  "// postinstall script": "Verifies that cocos-cli is available after npm install",
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -23,6 +27,7 @@
     "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
+    "cocos-cli": "^0.1.25",
     "eslint": "^8.57.1",
     "husky": "^9.1.7",
     "jest": "^30.0.5",
@@ -32,11 +37,10 @@
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"
   },
+  "// cocos-cli dev dependency": "Provides the CLI used by build:web",
   "lint-staged": {
     "*.ts": [
       "prettier --write"
     ]
-  },
-  "dependencies": {
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,12 @@
 [![CI](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/build.yml/badge.svg)](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/build.yml)
 [![Tests](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/build.yml/badge.svg?label=Tests)](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/build.yml)
 
+[![Deploy](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/gh-pages.yml) <!-- Badge for Pages deployment workflow -->
+
+➜ Live build: https://rebbort.github.io/blast-puzzle-test-game/ <!-- Link to published web build -->
+
+Installing dependencies with `npm install` also fetches the `cocos-cli` used by `npm run build:web`. <!-- Note about CLI installation and usage -->
+
 This project contains a prototype for a Blast puzzle game. The badge above shows the status of the CI workflow which runs linting and type checking on every push to `main`.
 
 ## Running tests


### PR DESCRIPTION
## Summary
- ignore and track web build placeholder, plus GitHub Pages workflow and npm script for web build
- add deployment badge and live link to README
- include cocos-cli dev dependency with postinstall check and document its use

## Testing
- `npm run postinstall`
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688fa4dc3b748320b1087ceaf4d53316