### PR TITLE
fix: ensure chain-triggered bombs clear full 3x3 area

### DIFF
--- a/__tests__/core/boosters/BoardSolverSuper.spec.ts
+++ b/__tests__/core/boosters/BoardSolverSuper.spec.ts
@@ -34,7 +34,7 @@ it("expandGroupForSuper handles all kinds", () => {
   const bombTile = TileFactory.createNormal("red");
   bombTile.kind = TileKind.SuperBomb;
   const bombRes = solver.expandGroupForSuper(bombTile, new cc.Vec2(2, 2));
-  expect(bombRes).toHaveLength(5);
+  expect(bombRes).toHaveLength(9);
   expect(bombRes).toEqual(
     expect.arrayContaining([
       new cc.Vec2(2, 2),
@@ -42,6 +42,10 @@ it("expandGroupForSuper handles all kinds", () => {
       new cc.Vec2(3, 2),
       new cc.Vec2(2, 1),
       new cc.Vec2(2, 3),
+      new cc.Vec2(1, 1),
+      new cc.Vec2(1, 3),
+      new cc.Vec2(3, 1),
+      new cc.Vec2(3, 3),
     ]),
   );
 

--- a/assets/scripts/core/board/BoardSolver.ts
+++ b/assets/scripts/core/board/BoardSolver.ts
@@ -45,7 +45,7 @@ export class BoardSolver {
         const cells: cc.Vec2[] = [];
         for (let dx = -radius; dx <= radius; dx++) {
           for (let dy = -radius; dy <= radius; dy++) {
-            if (dx * dx + dy * dy <= radius * radius) {
+            if (Math.max(Math.abs(dx), Math.abs(dy)) <= radius) {
               const p = new cc.Vec2(pos.x + dx, pos.y + dy);
               if (this.board.inBounds(p)) cells.push(p);
             }


### PR DESCRIPTION
## Summary
- make chain-triggered SuperBombs clear a 3x3 square like direct activations
- update unit tests for expanded blast radius

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe59920a08320891853e53cc3fb51