### PR TITLE
docs: add player guide and usage section

### DIFF
--- a/docs/player-guide.md
+++ b/docs/player-guide.md
@@ -1,0 +1,30 @@
+# Player Guide
+
+## Game Rules and Objective
+- Tap groups of two or more adjacent tiles of the same color to clear them.
+- Each move removes the selected group and awards points based on its size.
+- Larger groups create super tiles that can clear extra tiles when triggered.
+- The goal of each level is to reach the target score before you run out of moves.
+
+## Controls
+- **Tap / Click** a tile group to remove it.
+- **Select boosters** from the toolbar and then tap the board to apply them.
+- **Super tiles** activate when tapped directly or when their group is cleared.
+
+## Boosters
+- **Teleport** – swap any two tiles on the board.
+- **Bomb Maker** – converts a tile into a bomb that explodes in a 3×3 radius.
+- **Super Row** – transforms a tile into a row-clearing super tile.
+- **Super Column** – transforms a tile into a column-clearing super tile.
+
+## Super Tiles
+- **Bomb** – explodes in a small radius around the tile.
+- **Row Blaster** – clears the entire row.
+- **Column Blaster** – clears the entire column.
+- **Board Clear** – removes all tiles on the board.
+
+## Win, Loss, and Scoring
+- You **win** when your score meets or exceeds the target before moves run out.
+- You **lose** if you use all moves and no shuffles remain.
+- The board automatically shuffles when no moves are left (limited times).
+- Score is calculated with a quadratic formula: `(group size - 1)^2` points, encouraging big combos.

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ Installing dependencies with `npm install` also fetches the `cocos-cli` used by 
 
 This project contains a prototype for a Blast puzzle game. The badge above shows the status of the CI workflow which runs linting and type checking on every push to `main`.
 
+## How to Play
+
+For a rundown of rules, controls, boosters and scoring see the [Player Guide](docs/player-guide.md).
+
 ## Running tests
 
 Install dependencies once with `npm install` if needed, then run:


### PR DESCRIPTION
## Summary
- add player guide covering rules, boosters, super tiles and scoring
- link to player guide from README via new "How to Play" section

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6890605b1ff48320aa3b41e1bc0a884e