### PR TITLE
fix: build web assets in gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-# Deploy prebuilt web assets to GitHub Pages
+# Build and deploy web assets to GitHub Pages
 name: Deploy # Human-friendly name for the workflow
 
 on:
@@ -14,14 +14,20 @@ jobs:
         uses: actions/checkout@v4 # Fetch repository contents
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4 # Provide Node for optional build steps
+        uses: actions/setup-node@v4 # Provide Node for build step
         with:
           node-version: 20 # Utilize Node 20 LTS
+
+      - name: Install dependencies
+        run: npm ci # Install exact versions from package-lock.json
+
+      - name: Build web assets
+        run: npm run build:web # Generate build/web-mobile
 
       - name: Prepare deployment folder
         run: |
           mkdir -p deploy # Create directory for deployment artifacts
-          cp -r build/web/* deploy/ # Copy pre-built web files
+          cp -r build/web-mobile/* deploy/ # Copy built web files
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4 # Push files to gh-pages branch

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "lint": "eslint --config .eslintrc.cjs \"**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "prepare": "husky install",
-    "build:web": "cocos-cli build --platform web-mobile --output build/web # build web version into build/web",
-    "postinstall": "npx cocos-cli --version # confirm cocos CLI is installed"
+    "build:web": "cocoscli build --platform web-mobile # build web-mobile version into build/web-mobile",
+    "postinstall": "npx cocoscli --version # confirm cocos CLI is installed"
   },
-  "// build:web script": "Generates the web-mobile build into build/web for GitHub Pages",
-  "// postinstall script": "Verifies that cocos-cli is available after npm install",
+  "// build:web script": "Generates the web-mobile build into build/web-mobile for GitHub Pages",
+  "// postinstall script": "Verifies that cocoscli is available after npm install",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ➜ Live build: https://rebbort.github.io/blast-puzzle-test-game/ <!-- Link to published web build -->
 
-Installing dependencies with `npm install` also fetches the `cocos-cli` used by `npm run build:web`. <!-- Note about CLI installation and usage -->
+Installing dependencies with `npm install` also fetches the `cocoscli` used by `npm run build:web`. <!-- Note about CLI installation and usage -->
 
 This project contains a prototype for a Blast puzzle game. The badge above shows the status of the CI workflow which runs linting and type checking on every push to `main`.
 


### PR DESCRIPTION
## Summary
- run npm build before Pages deploy and copy from `web-mobile`
- ensure `cocoscli` scripts are used for web build

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890619cf9ec8320a8543aaff451e383