### PR TITLE
chore: require manual gh-pages deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,9 +2,7 @@
 name: Deploy # Human-friendly name for the workflow
 
 on:
-  push:
-    branches:
-      - main # Trigger only when committing to main branch
+  workflow_dispatch: # Allow manual runs only
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- prevent automatic gh-pages deployment by requiring manual workflow dispatch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68906325faac83209e121fe8cdd53094