### PR TITLE
chore: ensure event listeners are cleaned up

### DIFF
--- a/assets/scripts/GameScene.ts
+++ b/assets/scripts/GameScene.ts
@@ -21,6 +21,7 @@ export default class GameScene extends cc.Component {
   private executor!: MoveExecutor;
   private scoreStrategy!: ScoreStrategyQuadratic;
   private turns!: TurnManager;
+  private logger: MoveSequenceLogger | null = null;
   private currentState: GameState = "WaitingInput";
 
   private onStateChange = (s: GameState): void => {
@@ -71,7 +72,7 @@ export default class GameScene extends cc.Component {
     this.turns = new TurnManager(20, EventBus);
 
     // Diagnostic helper that tracks event sequence for each move.
-    new MoveSequenceLogger(EventBus, board);
+    this.logger = new MoveSequenceLogger(EventBus, board);
 
     EventBus.on(EventNames.StateChanged, this.onStateChange);
     EventBus.on(EventNames.BoostersSelected, this.onBoostersSelected);
@@ -89,6 +90,8 @@ export default class GameScene extends cc.Component {
   }
 
   onDestroy(): void {
+    this.fsm?.destroy();
+    this.logger?.destroy();
     EventBus.off(EventNames.StateChanged, this.onStateChange);
     EventBus.off(EventNames.BoostersSelected, this.onBoostersSelected);
     EventBus.off(EventNames.GameRestart, this.onGameRestart);

--- a/assets/scripts/core/game/GameStateMachine.ts
+++ b/assets/scripts/core/game/GameStateMachine.ts
@@ -42,17 +42,21 @@ export class GameStateMachine {
     private maxShuffles: number = 3,
   ) {}
 
+  private groupSelectedHandler = (p: cc.Vec2): void => this.onGroupSelected(p);
+  private boosterActivatedHandler = (): void => this.onBoosterActivated();
+  private boosterConsumedHandler = (): void => this.onBoosterConsumed();
+  private boosterCancelledHandler = (): void => this.onBoosterCancelled();
+  private moveCompletedHandler = (): void => this.onMoveCompleted();
+
   /**
    * Subscribe to relevant events and enter the initial WaitingInput state.
    */
   start(): void {
-    this.bus.on(EventNames.GroupSelected, (p: cc.Vec2) =>
-      this.onGroupSelected(p),
-    );
-    this.bus.on(EventNames.BoosterActivated, () => this.onBoosterActivated());
-    this.bus.on(EventNames.BoosterConsumed, () => this.onBoosterConsumed());
-    this.bus.on(EventNames.BoosterCancelled, () => this.onBoosterCancelled());
-    this.bus.on(EventNames.MoveCompleted, () => this.onMoveCompleted());
+    this.bus.on(EventNames.GroupSelected, this.groupSelectedHandler);
+    this.bus.on(EventNames.BoosterActivated, this.boosterActivatedHandler);
+    this.bus.on(EventNames.BoosterConsumed, this.boosterConsumedHandler);
+    this.bus.on(EventNames.BoosterCancelled, this.boosterCancelledHandler);
+    this.bus.on(EventNames.MoveCompleted, this.moveCompletedHandler);
     console.debug(
       "Listeners for GroupSelected:",
       this.bus.getListenerCount(EventNames.GroupSelected),
@@ -90,6 +94,14 @@ export class GameStateMachine {
     this.bus.emit(EventNames.TurnEnded, { score: this.score });
 
     this.changeState("WaitingInput");
+  }
+
+  destroy(): void {
+    this.bus.off(EventNames.GroupSelected, this.groupSelectedHandler);
+    this.bus.off(EventNames.BoosterActivated, this.boosterActivatedHandler);
+    this.bus.off(EventNames.BoosterConsumed, this.boosterConsumedHandler);
+    this.bus.off(EventNames.BoosterCancelled, this.boosterCancelledHandler);
+    this.bus.off(EventNames.MoveCompleted, this.moveCompletedHandler);
   }
 
   /**

--- a/assets/scripts/ui/controllers/BoosterSelectPopup.ts
+++ b/assets/scripts/ui/controllers/BoosterSelectPopup.ts
@@ -26,6 +26,7 @@ export default class BoosterSelectPopup extends cc.Component {
 
   private slots: BoosterSlot[] = [];
   private animationController: BoosterSelectAnimationController = null;
+  private onPlayButton = (): void => this.startGame();
 
   onLoad(): void {
     this.animationController = this.getComponent(
@@ -43,7 +44,7 @@ export default class BoosterSelectPopup extends cc.Component {
 
   start(): void {
     const playButton = this.node.getChildByName("PlayButton");
-    playButton?.on(cc.Node.EventType.TOUCH_END, () => this.startGame());
+    playButton?.on(cc.Node.EventType.TOUCH_END, this.onPlayButton, this);
   }
 
   private createSlots(): void {
@@ -135,5 +136,11 @@ export default class BoosterSelectPopup extends cc.Component {
     if (this.animationController) {
       this.animationController.showAllImmediately();
     }
+  }
+
+  onDestroy(): void {
+    const playButton = this.node.getChildByName("PlayButton");
+    playButton?.off(cc.Node.EventType.TOUCH_END, this.onPlayButton, this);
+    this.slots.forEach((s) => s.node.off(cc.Node.EventType.TOUCH_END));
   }
 }

--- a/assets/scripts/ui/controllers/FillController.ts
+++ b/assets/scripts/ui/controllers/FillController.ts
@@ -31,6 +31,11 @@ export default class FillController extends cc.Component {
     bus.on(EventNames.FillDone, this.onFillDone, this);
   }
 
+  onDestroy(): void {
+    bus.off(EventNames.FillStarted, this.onFillStarted, this);
+    bus.off(EventNames.FillDone, this.onFillDone, this);
+  }
+
   /**
    * Spawns visual tiles for new board pieces created by FillCommand.
    * Core.FillCommand updates the model before emitting FillStarted so the

--- a/assets/scripts/ui/controllers/GameBoardController.ts
+++ b/assets/scripts/ui/controllers/GameBoardController.ts
@@ -256,4 +256,15 @@ export default class GameBoardController extends cc.Component {
       }
     }
   }
+
+  onDestroy(): void {
+    bus.off(EventNames.BoosterConfirmed, this.onBoosterConfirmed, this);
+    bus.off(
+      EventNames.BoosterTargetSelected,
+      this.onBoosterTargetSelected,
+      this,
+    );
+    bus.off(EventNames.BoosterCancelled, this.clearTeleportHighlight, this);
+    bus.off(EventNames.SwapDone, this.onSwapDone, this);
+  }
 }

--- a/assets/scripts/ui/controllers/HudController.ts
+++ b/assets/scripts/ui/controllers/HudController.ts
@@ -31,6 +31,7 @@ export class HudController extends cc.Component {
   private turns: number = 0;
   private score: number = 0;
   private targetScore: number = 0;
+  private pauseHandler = (): void => this.onPauseClick();
 
   onLoad(): void {
     // Update moves counter when a turn is consumed
@@ -67,7 +68,7 @@ export class HudController extends cc.Component {
       .getChildByName("btnPause")
       ?.getComponent("Button") as NodeUtils | null;
 
-    this.btnPause?.node?.on("click", this.onPauseClick.bind(this));
+    this.btnPause?.node?.on("click", this.pauseHandler);
 
     // Display current FSM state in the HUD
     EventBus.on(EventNames.StateChanged, this.onStateChanged, this);
@@ -142,5 +143,13 @@ export class HudController extends cc.Component {
    */
   private onStateChanged(state: string): void {
     if (this.lblState) this.lblState.string = state;
+  }
+
+  onDestroy(): void {
+    EventBus.off(EventNames.TurnUsed, this.onTurnUsed, this);
+    EventBus.off(EventNames.TurnEnded, this.onTurnEnded, this);
+    EventBus.off(EventNames.TurnsInit, this.onTurnsInit, this);
+    EventBus.off(EventNames.StateChanged, this.onStateChanged, this);
+    this.btnPause?.node?.off("click", this.pauseHandler);
   }
 }

--- a/assets/scripts/ui/controllers/MoveFlowController.ts
+++ b/assets/scripts/ui/controllers/MoveFlowController.ts
@@ -39,6 +39,14 @@ export default class MoveFlowController extends cc.Component {
     bus.on(EventNames.SuperTileActivated, this.onSuperTileActivated, this);
   }
 
+  onDestroy(): void {
+    bus.off(EventNames.RemoveStarted, this.onRemove, this);
+    bus.off(EventNames.FallDone, this.onFall, this);
+    bus.off(EventNames.FillDone, this.onFill, this);
+    bus.off(EventNames.SuperTileCreated, this.onSuperTileCreated, this);
+    bus.off(EventNames.SuperTileActivated, this.onSuperTileActivated, this);
+  }
+
   /**
    * Plays scale + fade animation on removed tile views.
    * @param positions coordinates of tiles removed by the core

--- a/assets/scripts/ui/controllers/TileInputController.ts
+++ b/assets/scripts/ui/controllers/TileInputController.ts
@@ -12,6 +12,19 @@ export default class TileInputController extends cc.Component {
   tilesLayer: cc.Node = null;
 
   private boardCtrl!: GameBoardController;
+  private onTouchEnd = (e: cc.Event.EventTouch): void => {
+    const worldPos = e.getLocation();
+    const local = this.tilesLayer.convertToNodeSpaceAR(worldPos);
+    // convert node-space coordinates to column/row using tile size
+    const col = Math.floor(
+      (local.x + this.tilesLayer.width / 2) / loadBoardConfig().tileWidth,
+    );
+    const row = Math.floor(
+      (this.tilesLayer.height / 2 - (local.y - 12)) /
+        loadBoardConfig().tileHeight,
+    );
+    this.handleTap(col, row);
+  };
 
   onLoad(): void {
     this.boardCtrl = this.getComponent(GameBoardController)!;
@@ -23,23 +36,11 @@ export default class TileInputController extends cc.Component {
     }
 
     // Attach a single click listener on the tilesLayer node
-    this.tilesLayer.on(
-      cc.Node.EventType.TOUCH_END,
-      (e: cc.Event.EventTouch) => {
-        const worldPos = e.getLocation();
-        const local = this.tilesLayer.convertToNodeSpaceAR(worldPos);
-        // convert node-space coordinates to column/row using tile size
-        const col = Math.floor(
-          (local.x + this.tilesLayer.width / 2) / loadBoardConfig().tileWidth,
-        );
-        const row = Math.floor(
-          (this.tilesLayer.height / 2 - (local.y - 12)) /
-            loadBoardConfig().tileHeight,
-        );
-        this.handleTap(col, row);
-      },
-      this,
-    );
+    this.tilesLayer.on(cc.Node.EventType.TOUCH_END, this.onTouchEnd, this);
+  }
+
+  onDestroy(): void {
+    this.tilesLayer.off(cc.Node.EventType.TOUCH_END, this.onTouchEnd, this);
   }
 
   handleTap(col: number, row: number): void {

--- a/assets/scripts/ui/controllers/TilePressFeedback.ts
+++ b/assets/scripts/ui/controllers/TilePressFeedback.ts
@@ -13,6 +13,10 @@ export default class TilePressFeedback extends cc.Component {
     bus.on(EventNames.TilePressed, this.onTilePressed, this);
   }
 
+  onDestroy(): void {
+    bus.off(EventNames.TilePressed, this.onTilePressed, this);
+  }
+
   private onTilePressed(pos: cc.Vec2): void {
     const view = this.boardCtrl.tileViews[pos.y]?.[pos.x];
     view?.pressFeedback();


### PR DESCRIPTION
## Summary
- dispose event listeners in controllers to prevent leaks
- add destroy methods for FSM and sequence logger

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890757acb348320a98a8629095d50fa