### PR TITLE
ci: deploy release archive

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,57 +1,35 @@
 # .github/workflows/gh-pages.yml
 # ---------------------------------------------------------------
-# Deploy Web-Mobile build (Cocos Creator 2.4.x) to GitHub Pages.
-# — Trigger: manual “Run workflow” in the Actions tab (workflow_dispatch)
-# — Output: pushes contents of build/web/ → branch gh-pages
+# Deploy prebuilt Web-Mobile archive to GitHub Pages.
+# — Trigger: push to release branch
+# — Input: release.tar.gz archived build
+# — Output: contents published to gh-pages branch
 # ---------------------------------------------------------------
 
 name: Deploy
 
 on:
-  workflow_dispatch: # ← запускается вручную
+  push:
+    branches: [release]
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest # Linux-runner
-
+    runs-on: ubuntu-latest
     steps:
-      # 1) Получаем репозиторий с LFS-ассетами
       - name: Checkout source
         uses: actions/checkout@v4
         with:
-          lfs: true # ⚠️ тянем большие PNG/Prefab из Git LFS
+          lfs: true
 
-      # 2) Node.js для npm-скриптов / cocos-CLI
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20 # LTS 20
-
-      # 3) Устанавливаем зависимости (package-lock.json обязателен)
-      - name: Install dependencies
-        run: npm ci
-
-      # 4) Проверяем доступность cocoscli через npx
-      - name: Ensure cocos CLI is available
-        run: |
-          npx cocoscli --version      # логируем версию
-
-      # 5) Собираем Web-Mobile через npx cocoscli
-      - name: Build web assets
-        run: npm run build:web # → build/web-mobile/
-
-      # 6) Готовим папку для деплоя
-      - name: Prepare deployment folder
+      - name: Extract release archive
         run: |
           mkdir -p deploy
-          cp -r build/web-mobile/* deploy/
+          tar -xzf release.tar.gz -C deploy
 
-      # 7) Публикуем в ветку gh-pages
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} # токен по умолчанию
-          publish_branch: gh-pages # ветка для Pages
-          publish_dir: ./deploy # что именно пушим
-          force_orphan: true # чистая история
-
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./deploy
+          force_orphan: true

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "typecheck": "tsc --noEmit",
     "prepare": "husky install",
     "build:web": "npx cocoscli build --platform web-mobile --output build/web-mobile",
-    "postinstall": "npx cocoscli --version # confirm cocos CLI is installed"
+    "postinstall": "npx cocoscli --version # confirm cocos CLI is installed",
+    "release:archive": "tar -C build -czf release.tar.gz web-mobile"
   },
   "// build:web script": "Generates the web-mobile build into build/web-mobile for GitHub Pages",
   "// postinstall script": "Verifies that cocoscli is available after npm install",
+  "// release:archive script": "Packages build/web-mobile into release.tar.gz for pushing to the release branch",
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- package built web-mobile into `release.tar.gz` via new script
- deploy workflow unpacks release archive pushed to `release` branch

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run release:archive`


------
https://chatgpt.com/codex/tasks/task_e_6890852594c48320ad0bedfcf5feebf7