### PR TITLE
chore: remove cocoscli references

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,8 @@
     "lint": "eslint --config .eslintrc.cjs \"**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "prepare": "husky install",
-    "build:web": "npx cocoscli build --platform web-mobile --output build/web-mobile",
-    "postinstall": "npx cocoscli --version # confirm cocos CLI is installed",
     "release:archive": "tar -C build -czf release.tar.gz web-mobile"
   },
-  "// build:web script": "Generates the web-mobile build into build/web-mobile for GitHub Pages",
-  "// postinstall script": "Verifies that cocoscli is available after npm install",
   "// release:archive script": "Packages build/web-mobile into release.tar.gz for pushing to the release branch",
   "keywords": [],
   "author": "",
@@ -38,7 +34,6 @@
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"
   },
-  "// cocos-cli dev dependency": "Provides the CLI used by build:web",
   "lint-staged": {
     "*.ts": [
       "prettier --write"

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,6 @@
 [![Deploy](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/rebbort/blast-puzzle-test-game/actions/workflows/gh-pages.yml) <!-- Badge for Pages deployment workflow -->
 
 ➜ Live build: https://rebbort.github.io/blast-puzzle-test-game/ <!-- Link to published web build -->
-
-Installing dependencies with `npm install` also fetches the `cocoscli` used by `npm run build:web`. <!-- Note about CLI installation and usage -->
-
 This project contains a prototype for a Blast puzzle game. The badge above shows the status of the CI workflow which runs linting and type checking on every push to `main`.
 
 ## How to Play


### PR DESCRIPTION
## Summary
- remove cocoscli scripts from package.json
- drop mention of cocoscli from documentation

## Testing
- `npm ci`
- `npm test --silent >/tmp/npm-test.out 2>/tmp/npm-test.err` *(fails? no - passed? but we show summary from tail - yes)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689094eb1c608320a0d46fa5cefbe5dd